### PR TITLE
Rename `internal` and friends

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -28,9 +28,9 @@
 PLUGIN_GLOBALVARS();
 
 // these are for searchability, because static behaves differently in different scopes.
-#define internal      static // static functions & static global variables
-#define local_persist static // static local variables
-#define static_global static // static class functions
+#define static_global   static // static global variables
+#define static_persist  static // static local variables
+#define static_function static // static functions
 
 typedef int8 i8;
 typedef int16 i16;

--- a/src/common.h
+++ b/src/common.h
@@ -27,7 +27,8 @@
 
 PLUGIN_GLOBALVARS();
 
-// these are for searchability, because static behaves differently in different scopes.
+// These are for searchability, because static behaves differently in different scopes.
+// Regular static is for static class functions.
 #define static_global   static // static global variables
 #define static_persist  static // static local variables
 #define static_function static // static functions

--- a/src/cs2kz.cpp
+++ b/src/cs2kz.cpp
@@ -83,7 +83,7 @@ void KZPlugin::AllPluginsLoaded()
 
 void KZPlugin::AddonInit()
 {
-	local_persist bool addonLoaded;
+	static_persist bool addonLoaded;
 	if (g_pMultiAddonManager != nullptr && !addonLoaded)
 	{
 		g_pMultiAddonManager->AddAddon(KZ_WORKSHOP_ADDONS_ID);

--- a/src/kz/checkpoint/commands.cpp
+++ b/src/kz/checkpoint/commands.cpp
@@ -1,49 +1,49 @@
 #include "kz_checkpoint.h"
 #include "utils/simplecmds.h"
 
-internal SCMD_CALLBACK(Command_KzUndoTeleport)
+static_function SCMD_CALLBACK(Command_KzUndoTeleport)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->checkpointService->UndoTeleport();
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_KzCheckpoint)
+static_function SCMD_CALLBACK(Command_KzCheckpoint)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->checkpointService->SetCheckpoint();
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_KzTeleport)
+static_function SCMD_CALLBACK(Command_KzTeleport)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->checkpointService->TpToCheckpoint();
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_KzPrevcp)
+static_function SCMD_CALLBACK(Command_KzPrevcp)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->checkpointService->TpToPrevCp();
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_KzNextcp)
+static_function SCMD_CALLBACK(Command_KzNextcp)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->checkpointService->TpToNextCp();
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_SetStartPos)
+static_function SCMD_CALLBACK(Command_SetStartPos)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->checkpointService->SetStartPosition();
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_ClearStartPos)
+static_function SCMD_CALLBACK(Command_ClearStartPos)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->checkpointService->ClearStartPosition();

--- a/src/kz/checkpoint/kz_checkpoint.cpp
+++ b/src/kz/checkpoint/kz_checkpoint.cpp
@@ -7,7 +7,7 @@
 
 // TODO: replace printchat with HUD service's printchat
 
-internal const Vector NULL_VECTOR = Vector(0, 0, 0);
+static_global const Vector NULL_VECTOR = Vector(0, 0, 0);
 
 void KZCheckpointService::Reset()
 {

--- a/src/kz/checkpoint/kz_checkpoint.h
+++ b/src/kz/checkpoint/kz_checkpoint.h
@@ -31,7 +31,7 @@ public:
 		bool teleportInAntiCpTrigger {};
 	};
 
-	static_global void RegisterCommands();
+	static void RegisterCommands();
 
 private:
 	i32 currentCpIndex {};

--- a/src/kz/hud/kz_hud.cpp
+++ b/src/kz/hud/kz_hud.cpp
@@ -11,7 +11,7 @@
 #include "tier0/memdbgon.h"
 
 #define HUD_ON_GROUND_THRESHOLD 0.07f
-internal KZHUDServiceTimerEventListener timerEventListener;
+static_global KZHUDServiceTimerEventListener timerEventListener;
 
 void KZHUDService::Init()
 {
@@ -161,7 +161,7 @@ void KZHUDServiceTimerEventListener::OnTimerEndPost(KZPlayer *player, const char
 	player->hudService->OnTimerStopped(time);
 }
 
-internal SCMD_CALLBACK(Command_KzPanel)
+static_function SCMD_CALLBACK(Command_KzPanel)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->hudService->TogglePanel();

--- a/src/kz/hud/kz_hud.h
+++ b/src/kz/hud/kz_hud.h
@@ -21,8 +21,8 @@ private:
 
 public:
 	virtual void Reset() override;
-	static_global void Init();
-	static_global void RegisterCommands();
+	static void Init();
+	static void RegisterCommands();
 	void DrawPanels(KZPlayer *target);
 
 	void TogglePanel();

--- a/src/kz/jumpstats/kz_jumpstats.cpp
+++ b/src/kz/jumpstats/kz_jumpstats.cpp
@@ -1044,28 +1044,28 @@ void KZJumpstatsService::SetSoundMinTier(const char *tierString)
 	}
 }
 
-internal SCMD_CALLBACK(Command_KzToggleJumpstats)
+static_function SCMD_CALLBACK(Command_KzToggleJumpstats)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->jumpstatsService->ToggleJumpstatsReporting();
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_KzJSAlways)
+static_function SCMD_CALLBACK(Command_KzJSAlways)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->jumpstatsService->ToggleJSAlways();
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_KzJsPrintMinTier)
+static_function SCMD_CALLBACK(Command_KzJsPrintMinTier)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->jumpstatsService->SetBroadcastMinTier(args->Arg(1));
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_KzJsSoundMinTier)
+static_function SCMD_CALLBACK(Command_KzJsSoundMinTier)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->jumpstatsService->SetSoundMinTier(args->Arg(1));

--- a/src/kz/jumpstats/kz_jumpstats.h
+++ b/src/kz/jumpstats/kz_jumpstats.h
@@ -176,7 +176,7 @@ public:
 	// Closer to 100 if it passes the optimal value.
 	// Note: if the player jumps in place, no velocity and no attempt to move at all, any angle will be "perfect".
 	// Returns false if there is no available stats.
-	internal int SortFloat(const f32 *a, const f32 *b)
+	static int SortFloat(const f32 *a, const f32 *b)
 	{
 		return *a > *b;
 	}
@@ -397,9 +397,9 @@ private:
 	bool possibleEdgebug {};
 
 public:
-	static_global void RegisterCommands();
+	static void RegisterCommands();
 
-	static_global DistanceTier GetDistTierFromString(const char *tierString);
+	static DistanceTier GetDistTierFromString(const char *tierString);
 
 	void SetBroadcastMinTier(const char *tierString);
 	void SetSoundMinTier(const char *tierString);
@@ -452,8 +452,8 @@ public:
 	void DetectInvalidGains();
 	void DetectExternalModifications();
 
-	static_global void BroadcastJumpToChat(Jump *jump);
-	static_global void PlayJumpstatSound(KZPlayer *target, Jump *jump);
-	static_global void PrintJumpToChat(KZPlayer *target, Jump *jump);
-	static_global void PrintJumpToConsole(KZPlayer *target, Jump *jump);
+	static void BroadcastJumpToChat(Jump *jump);
+	static void PlayJumpstatSound(KZPlayer *target, Jump *jump);
+	static void PrintJumpToChat(KZPlayer *target, Jump *jump);
+	static void PrintJumpToConsole(KZPlayer *target, Jump *jump);
 };

--- a/src/kz/kz_misc.cpp
+++ b/src/kz/kz_misc.cpp
@@ -15,7 +15,7 @@
 #include "timer/kz_timer.h"
 #include "tip/kz_tip.h"
 
-internal SCMD_CALLBACK(Command_KzHidelegs)
+static_function SCMD_CALLBACK(Command_KzHidelegs)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->ToggleHideLegs();
@@ -30,7 +30,7 @@ internal SCMD_CALLBACK(Command_KzHidelegs)
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_KzHide)
+static_function SCMD_CALLBACK(Command_KzHide)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->quietService->ToggleHide();
@@ -45,7 +45,7 @@ internal SCMD_CALLBACK(Command_KzHide)
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_KzRestart)
+static_function SCMD_CALLBACK(Command_KzRestart)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 
@@ -71,7 +71,7 @@ internal SCMD_CALLBACK(Command_KzRestart)
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_KzHideWeapon)
+static_function SCMD_CALLBACK(Command_KzHideWeapon)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->quietService->ToggleHideWeapon();
@@ -86,7 +86,7 @@ internal SCMD_CALLBACK(Command_KzHideWeapon)
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_JoinTeam)
+static_function SCMD_CALLBACK(Command_JoinTeam)
 {
 	KZ::misc::JoinTeam(g_pKZPlayerManager->ToPlayer(controller), atoi(args->Arg(1)), false);
 	return MRES_SUPERCEDE;

--- a/src/kz/kz_player_print.cpp
+++ b/src/kz/kz_player_print.cpp
@@ -21,7 +21,7 @@
 	} \
 	va_end(args);
 
-internal CRecipientFilter *CreateRecipientFilter(KZPlayer *targetPlayer, bool addSpectators)
+static_function CRecipientFilter *CreateRecipientFilter(KZPlayer *targetPlayer, bool addSpectators)
 {
 	if (!targetPlayer->GetController())
 	{

--- a/src/kz/language/kz_language.cpp
+++ b/src/kz/language/kz_language.cpp
@@ -10,8 +10,8 @@
 
 extern IClientCvarValue *g_pClientCvarValue;
 
-internal KeyValues *translationKV;
-internal KeyValues *languagesKV;
+static_global KeyValues *translationKV;
+static_global KeyValues *languagesKV;
 
 void KZLanguageService::Init()
 {
@@ -104,7 +104,7 @@ const char *KZLanguageService::GetTranslatedFormat(const char *language, const c
 	return outFormat;
 }
 
-internal SCMD_CALLBACK(Command_KzSetLanguage)
+static_function SCMD_CALLBACK(Command_KzSetLanguage)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	char language[32] {};

--- a/src/kz/language/kz_language.h
+++ b/src/kz/language/kz_language.h
@@ -9,10 +9,10 @@ class KZLanguageService : public KZBaseService
 	using KZBaseService::KZBaseService;
 
 public:
-	static_global void Init();
-	static_global void LoadLanguages();
-	static_global void LoadTranslations();
-	static_global void RegisterCommands();
+	static void Init();
+	static void LoadLanguages();
+	static void LoadTranslations();
+	static void RegisterCommands();
 
 	virtual void Reset() override
 	{
@@ -29,10 +29,10 @@ public:
 
 	const char *GetLanguage();
 
-	static_global const char *GetTranslatedFormat(const char *language, const char *phrase);
+	static const char *GetTranslatedFormat(const char *language, const char *phrase);
 
 private:
-	static_global inline void ReplaceStringInPlace(std::string &subject, std::string_view search, std::string_view replace)
+	static inline void ReplaceStringInPlace(std::string &subject, std::string_view search, std::string_view replace)
 	{
 		size_t pos = 0;
 		while ((pos = subject.find(search, pos)) != std::string::npos)
@@ -43,7 +43,7 @@ private:
 	}
 
 	template<typename... Args>
-	static_global std::string GetFormattedMessage(const char *input, const char *format, Args &&...args)
+	static std::string GetFormattedMessage(const char *input, const char *format, Args &&...args)
 	{
 		std::string inputStr = std::string(input);
 		const char *tokenStart = format;
@@ -76,7 +76,7 @@ private:
 
 public:
 	template<typename... Args>
-	static_global std::string PrepareMessage(const char *language, const char *message, Args &&...args)
+	static std::string PrepareMessage(const char *language, const char *message, Args &&...args)
 	{
 		const char *paramFormat = GetTranslatedFormat("#format", message);
 		const char *msgFormat = GetTranslatedFormat(language, message);
@@ -99,7 +99,7 @@ private:
 	};
 
 	template<typename... Args>
-	static_global void PrintType(KZPlayer *player, bool addPrefix, MessageType type, const char *message, Args &&...args)
+	static void PrintType(KZPlayer *player, bool addPrefix, MessageType type, const char *message, Args &&...args)
 	{
 		const char *language = player->languageService->GetLanguage();
 		std::string msg = PrepareMessage(language, message, args...);
@@ -134,7 +134,7 @@ private:
 	}
 
 	template<typename... Args>
-	static_global void PrintSingle(KZPlayer *player, bool addPrefix, bool includeSpectators, MessageType type, const char *message, Args &&...args)
+	static void PrintSingle(KZPlayer *player, bool addPrefix, bool includeSpectators, MessageType type, const char *message, Args &&...args)
 	{
 		PrintType(player, addPrefix, type, message, args...);
 		if (includeSpectators)
@@ -164,7 +164,7 @@ public:
 
 #define REGISTER_PRINT_ALL_FUNCTION(name, type) \
 	template<typename... Args> \
-	static_global void name(bool addPrefix, const char *message, Args &&...args) \
+	static void name(bool addPrefix, const char *message, Args &&...args) \
 	{ \
 		for (u32 i = 0; i < MAXPLAYERS + 1; i++) \
 		{ \

--- a/src/kz/mode/kz_mode_ckz.cpp
+++ b/src/kz/mode/kz_mode_ckz.cpp
@@ -667,7 +667,7 @@ void KZClassicModeService::SlopeFix()
 	}
 }
 
-internal void ClipVelocity(Vector &in, Vector &normal, Vector &out)
+static_function void ClipVelocity(Vector &in, Vector &normal, Vector &out)
 {
 	// Determine how far along plane to slide based on incoming direction.
 	f32 backoff = DotProduct(in, normal);
@@ -685,7 +685,7 @@ internal void ClipVelocity(Vector &in, Vector &normal, Vector &out)
 	}
 }
 
-internal bool IsValidMovementTrace(trace_t &tr, bbox_t bounds, CTraceFilterPlayerMovementCS *filter)
+static_function bool IsValidMovementTrace(trace_t &tr, bbox_t bounds, CTraceFilterPlayerMovementCS *filter)
 {
 	trace_t stuck;
 	// Maybe we don't need this one.

--- a/src/kz/mode/kz_mode_manager.cpp
+++ b/src/kz/mode/kz_mode_manager.cpp
@@ -11,10 +11,10 @@
 #include "utils/simplecmds.h"
 #include "utils/plat.h"
 
-internal SCMD_CALLBACK(Command_KzModeShort);
-internal SCMD_CALLBACK(Command_KzMode);
+static_function SCMD_CALLBACK(Command_KzModeShort);
+static_function SCMD_CALLBACK(Command_KzMode);
 
-internal KZModeManager modeManager;
+static_global KZModeManager modeManager;
 KZModeManager *g_pKZModeManager = &modeManager;
 
 bool KZ::mode::InitModeCvars()
@@ -36,7 +36,7 @@ bool KZ::mode::InitModeCvars()
 
 void KZ::mode::InitModeManager()
 {
-	static bool initialized = false;
+	static_persist bool initialized = false;
 	if (initialized)
 	{
 		return;
@@ -269,14 +269,14 @@ void KZModeManager::Cleanup()
 	}
 }
 
-internal SCMD_CALLBACK(Command_KzMode)
+static_function SCMD_CALLBACK(Command_KzMode)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	modeManager.SwitchToMode(player, args->Arg(1));
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_KzModeShort)
+static_function SCMD_CALLBACK(Command_KzModeShort)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	// Strip kz_ prefix if exist.

--- a/src/kz/mode/kz_mode_vnl.cpp
+++ b/src/kz/mode/kz_mode_vnl.cpp
@@ -46,7 +46,7 @@ void KZVanillaModeService::Reset()
 	this->tpmTriggerFixOrigins.RemoveAll();
 }
 
-internal void ClipVelocity(Vector &in, Vector &normal, Vector &out)
+static_function void ClipVelocity(Vector &in, Vector &normal, Vector &out)
 {
 	// Determine how far along plane to slide based on incoming direction.
 	f32 backoff = DotProduct(in, normal);

--- a/src/kz/noclip/kz_noclip.cpp
+++ b/src/kz/noclip/kz_noclip.cpp
@@ -55,7 +55,7 @@ void KZNoclipService::HandleNoclip()
 
 // Commands
 
-internal SCMD_CALLBACK(Command_KzNoclip)
+static_function SCMD_CALLBACK(Command_KzNoclip)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->noclipService->ToggleNoclip();

--- a/src/kz/noclip/kz_noclip.h
+++ b/src/kz/noclip/kz_noclip.h
@@ -12,7 +12,7 @@ private:
 	bool inNoclip {};
 
 public:
-	static_global void RegisterCommands();
+	static void RegisterCommands();
 
 	void DisableNoclip()
 	{

--- a/src/kz/option/kz_option.cpp
+++ b/src/kz/option/kz_option.cpp
@@ -1,6 +1,6 @@
 #include "kz_option.h"
 
-internal KeyValues *pServerCfgKeyValues;
+static_global KeyValues *pServerCfgKeyValues;
 
 void KZOptionService::LoadDefaultOptions()
 {

--- a/src/kz/option/kz_option.h
+++ b/src/kz/option/kz_option.h
@@ -10,10 +10,10 @@ class KZOptionService : public KZBaseService
 	using KZBaseService::KZBaseService;
 
 public:
-	static_global void InitOptions();
-	static_global const char *GetOptionStr(const char *optionName, const char *defaultValue = "");
-	static_global f64 GetOptionFloat(const char *optionName, f64 defaultValue = 0.0);
-	static_global i64 GetOptionInt(const char *optionName, i64 defaultValue = 0);
+	static void InitOptions();
+	static const char *GetOptionStr(const char *optionName, const char *defaultValue = "");
+	static f64 GetOptionFloat(const char *optionName, f64 defaultValue = 0.0);
+	static i64 GetOptionInt(const char *optionName, i64 defaultValue = 0);
 
 private:
 	static void LoadDefaultOptions();

--- a/src/kz/spec/kz_spec.cpp
+++ b/src/kz/spec/kz_spec.cpp
@@ -2,7 +2,7 @@
 
 #include "utils/simplecmds.h"
 
-internal KZSpecServiceTimerEventListener timerEventListener;
+static_global KZSpecServiceTimerEventListener timerEventListener;
 
 void KZSpecService::Reset()
 {
@@ -106,7 +106,7 @@ void KZSpecServiceTimerEventListener::OnTimerStartPost(KZPlayer *player, const c
 	player->specService->Reset();
 }
 
-internal SCMD_CALLBACK(Command_KzSpec)
+static_function SCMD_CALLBACK(Command_KzSpec)
 {
 	return MRES_HANDLED;
 }

--- a/src/kz/spec/kz_spec.h
+++ b/src/kz/spec/kz_spec.h
@@ -22,8 +22,8 @@ private:
 
 public:
 	virtual void Reset() override;
-	static_global void Init();
-	static_global void RegisterCommands();
+	static void Init();
+	static void RegisterCommands();
 	bool HasSavedPosition();
 	void SavePosition();
 	void LoadPosition();

--- a/src/kz/style/kz_style_manager.cpp
+++ b/src/kz/style/kz_style_manager.cpp
@@ -12,14 +12,14 @@
 #include "../language/kz_language.h"
 #include "utils/plat.h"
 
-internal SCMD_CALLBACK(Command_KzStyle);
+static_function SCMD_CALLBACK(Command_KzStyle);
 
-internal KZStyleManager styleManager;
+static_global KZStyleManager styleManager;
 KZStyleManager *g_pKZStyleManager = &styleManager;
 
 void KZ::style::InitStyleManager()
 {
-	static bool initialized = false;
+	static_persist bool initialized = false;
 	if (initialized)
 	{
 		return;
@@ -196,7 +196,7 @@ void KZ::style::InitStyleService(KZPlayer *player)
 	player->styleService = new KZNormalStyleService(player);
 }
 
-internal SCMD_CALLBACK(Command_KzStyle)
+static_function SCMD_CALLBACK(Command_KzStyle)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	styleManager.SwitchToStyle(player, args->Arg(1));

--- a/src/kz/timer/kz_timer.cpp
+++ b/src/kz/timer/kz_timer.cpp
@@ -7,7 +7,7 @@
 #include "utils/utils.h"
 #include "utils/simplecmds.h"
 
-internal CUtlVector<KZTimerServiceEventListener *> eventListeners;
+static_global CUtlVector<KZTimerServiceEventListener *> eventListeners;
 
 bool KZTimerService::RegisterEventListener(KZTimerServiceEventListener *eventListener)
 {
@@ -266,7 +266,7 @@ void KZTimerService::FormatTime(f64 time, char *output, u32 length, bool precise
 	}
 }
 
-internal std::string GetTeleportCountText(int tpCount, const char *language)
+static_function std::string GetTeleportCountText(int tpCount, const char *language)
 {
 	return tpCount == 1 ? KZLanguageService::PrepareMessage(language, "1 Teleport Text")
 						: KZLanguageService::PrepareMessage(language, "2+ Teleports Text", tpCount);
@@ -625,7 +625,7 @@ void KZTimerService::OnTeleport(const Vector *newPosition, const QAngle *newAngl
 	}
 }
 
-internal SCMD_CALLBACK(Command_KzStopTimer)
+static_function SCMD_CALLBACK(Command_KzStopTimer)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	if (player->timerService->GetTimerRunning())
@@ -635,7 +635,7 @@ internal SCMD_CALLBACK(Command_KzStopTimer)
 	return MRES_SUPERCEDE;
 }
 
-internal SCMD_CALLBACK(Command_KzPauseTimer)
+static_function SCMD_CALLBACK(Command_KzPauseTimer)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->timerService->TogglePause();

--- a/src/kz/timer/kz_timer.h
+++ b/src/kz/timer/kz_timer.h
@@ -73,9 +73,9 @@ private:
 	f64 lastInvalidateTime {};
 
 public:
-	static_global void RegisterCommands();
-	static_global bool RegisterEventListener(KZTimerServiceEventListener *eventListener);
-	static_global bool UnregisterEventListener(KZTimerServiceEventListener *eventListener);
+	static void RegisterCommands();
+	static bool RegisterEventListener(KZTimerServiceEventListener *eventListener);
+	static bool UnregisterEventListener(KZTimerServiceEventListener *eventListener);
 
 	bool GetTimerRunning()
 	{
@@ -92,7 +92,7 @@ public:
 		return currentTime;
 	}
 
-	static_global void FormatTime(f64 time, char *output, u32 length, bool precise = true);
+	static void FormatTime(f64 time, char *output, u32 length, bool precise = true);
 
 	void SetTime(f64 time)
 	{
@@ -142,7 +142,7 @@ public:
 private:
 	bool HasValidMoveType();
 
-	static_global bool IsValidMoveType(MoveType_t moveType)
+	static bool IsValidMoveType(MoveType_t moveType)
 	{
 		return moveType == MOVETYPE_WALK || moveType == MOVETYPE_LADDER || moveType == MOVETYPE_NONE || moveType == MOVETYPE_OBSERVER;
 	}
@@ -215,6 +215,6 @@ public:
 	void OnPlayerJoinTeam(i32 team);
 	void OnPlayerDeath();
 	void OnOptionsChanged();
-	static_global void OnRoundStart();
+	static void OnRoundStart();
 	void OnTeleport(const Vector *newPosition, const QAngle *newAngles, const Vector *newVelocity);
 };

--- a/src/kz/tip/kz_tip.cpp
+++ b/src/kz/tip/kz_tip.cpp
@@ -1,11 +1,11 @@
 #include "kz_tip.h"
 #include "../language/kz_language.h"
 
-internal KeyValues *pTipKeyValues;
-internal CUtlVector<const char *> tipNames;
-internal f64 tipInterval;
-internal i32 nextTipIndex;
-internal CTimer<> *tipTimer;
+static_global KeyValues *pTipKeyValues;
+static_global CUtlVector<const char *> tipNames;
+static_global f64 tipInterval;
+static_global i32 nextTipIndex;
+static_global CTimer<> *tipTimer;
 
 void KZTipService::Reset()
 {
@@ -74,7 +74,7 @@ void KZTipService::ShuffleTips()
 	}
 }
 
-internal SCMD_CALLBACK(Command_KzToggleTips)
+static_function SCMD_CALLBACK(Command_KzToggleTips)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->tipService->ToggleTips();

--- a/src/kz/tip/kz_tip.h
+++ b/src/kz/tip/kz_tip.h
@@ -19,8 +19,8 @@ private:
 public:
 	virtual void Reset() override;
 	void ToggleTips();
-	static_global void InitTips();
-	static_global f64 PrintTips();
+	static void InitTips();
+	static f64 PrintTips();
 
 private:
 	bool ShouldPrintTip();

--- a/src/player/player.h
+++ b/src/player/player.h
@@ -81,7 +81,7 @@ public:
 
 	const CSteamID &GetSteamId(bool validated = true)
 	{
-		local_persist const CSteamID invalidId = k_steamIDNil;
+		static_persist const CSteamID invalidId = k_steamIDNil;
 		if (validated && !IsAuthenticated())
 		{
 			return invalidId;

--- a/src/utils/ctimer.cpp
+++ b/src/utils/ctimer.cpp
@@ -3,7 +3,7 @@
 CUtlVector<CTimerBase *> g_NonPersistentTimers;
 CUtlVector<CTimerBase *> g_PersistentTimers;
 
-internal void ProcessTimerList(CUtlVector<CTimerBase *> &timers)
+static_function void ProcessTimerList(CUtlVector<CTimerBase *> &timers)
 {
 	for (int i = timers.Count() - 1; i >= 0; i--)
 	{

--- a/src/utils/hooks.cpp
+++ b/src/utils/hooks.cpp
@@ -24,97 +24,98 @@ class EntListener : public IEntityListener
 
 // CBaseEntity
 SH_DECL_MANUALHOOK1_void(StartTouch, 0, 0, 0, CBaseEntity *);
-internal void Hook_OnStartTouch(CBaseEntity *pOther);
-internal void Hook_OnStartTouchPost(CBaseEntity *pOther);
+static_function void Hook_OnStartTouch(CBaseEntity *pOther);
+static_function void Hook_OnStartTouchPost(CBaseEntity *pOther);
 SH_DECL_MANUALHOOK1_void(Touch, 0, 0, 0, CBaseEntity *);
-internal void Hook_OnTouch(CBaseEntity *pOther);
-internal void Hook_OnTouchPost(CBaseEntity *pOther);
+static_function void Hook_OnTouch(CBaseEntity *pOther);
+static_function void Hook_OnTouchPost(CBaseEntity *pOther);
 SH_DECL_MANUALHOOK1_void(EndTouch, 0, 0, 0, CBaseEntity *);
-internal void Hook_OnEndTouch(CBaseEntity *pOther);
-internal void Hook_OnEndTouchPost(CBaseEntity *pOther);
+static_function void Hook_OnEndTouch(CBaseEntity *pOther);
+static_function void Hook_OnEndTouchPost(CBaseEntity *pOther);
 SH_DECL_MANUALHOOK3_void(Teleport, 0, 0, 0, const Vector *, const QAngle *, const Vector *);
-internal void Hook_OnTeleport(const Vector *newPosition, const QAngle *newAngles, const Vector *newVelocity);
+static_function void Hook_OnTeleport(const Vector *newPosition, const QAngle *newAngles, const Vector *newVelocity);
 
 // CCSPlayerController
-internal int changeTeamHook {};
+static_global int changeTeamHook {};
 SH_DECL_MANUALHOOK1_void(ChangeTeam, 0, 0, 0, int);
-internal void Hook_OnChangeTeamPost(i32 team);
+static_function void Hook_OnChangeTeamPost(i32 team);
 
 // ISource2GameEntities
 SH_DECL_HOOK7_void(ISource2GameEntities, CheckTransmit, SH_NOATTRIB, false, CCheckTransmitInfo **, int, CBitVec<16384> &,
 				   const Entity2Networkable_t **, const uint16 *, int, bool);
-internal void Hook_CheckTransmit(CCheckTransmitInfo **pInfo, int, CBitVec<16384> &, const Entity2Networkable_t **pNetworkables,
-								 const uint16 *pEntityIndicies, int nEntities, bool bEnablePVSBits);
+static_function void Hook_CheckTransmit(CCheckTransmitInfo **pInfo, int, CBitVec<16384> &, const Entity2Networkable_t **pNetworkables,
+										const uint16 *pEntityIndicies, int nEntities, bool bEnablePVSBits);
 
 // ISource2Server
 SH_DECL_HOOK3_void(ISource2Server, GameFrame, SH_NOATTRIB, false, bool, bool, bool);
-internal void Hook_GameFrame(bool simulating, bool bFirstTick, bool bLastTick);
+static_function void Hook_GameFrame(bool simulating, bool bFirstTick, bool bLastTick);
 SH_DECL_HOOK0_void(ISource2Server, GameServerSteamAPIActivated, SH_NOATTRIB, 0);
-internal void Hook_GameServerSteamAPIActivated();
+static_function void Hook_GameServerSteamAPIActivated();
 SH_DECL_HOOK0_void(ISource2Server, GameServerSteamAPIDeactivated, SH_NOATTRIB, 0);
-internal void Hook_GameServerSteamAPIDeactivated();
+static_function void Hook_GameServerSteamAPIDeactivated();
 
 // ISource2GameClients
 SH_DECL_HOOK6(ISource2GameClients, ClientConnect, SH_NOATTRIB, false, bool, CPlayerSlot, const char *, uint64, const char *, bool, CBufferString *);
-internal bool Hook_ClientConnect(CPlayerSlot slot, const char *pszName, uint64 xuid, const char *pszNetworkID, bool unk1,
-								 CBufferString *pRejectReason);
+static_function bool Hook_ClientConnect(CPlayerSlot slot, const char *pszName, uint64 xuid, const char *pszNetworkID, bool unk1,
+										CBufferString *pRejectReason);
 
 SH_DECL_HOOK6_void(ISource2GameClients, OnClientConnected, SH_NOATTRIB, false, CPlayerSlot, const char *, uint64, const char *, const char *, bool);
-internal void Hook_OnClientConnected(CPlayerSlot slot, const char *pszName, uint64 xuid, const char *pszNetworkID, const char *pszAddress,
-									 bool bFakePlayer);
+static_function void Hook_OnClientConnected(CPlayerSlot slot, const char *pszName, uint64 xuid, const char *pszNetworkID, const char *pszAddress,
+											bool bFakePlayer);
 
 SH_DECL_HOOK1_void(ISource2GameClients, ClientFullyConnect, SH_NOATTRIB, false, CPlayerSlot);
-internal void Hook_ClientFullyConnect(CPlayerSlot slot);
+static_function void Hook_ClientFullyConnect(CPlayerSlot slot);
 
 SH_DECL_HOOK4_void(ISource2GameClients, ClientPutInServer, SH_NOATTRIB, false, CPlayerSlot, char const *, int, uint64);
-internal void Hook_ClientPutInServer(CPlayerSlot slot, char const *pszName, int type, uint64 xuid);
+static_function void Hook_ClientPutInServer(CPlayerSlot slot, char const *pszName, int type, uint64 xuid);
 
 SH_DECL_HOOK4_void(ISource2GameClients, ClientActive, SH_NOATTRIB, false, CPlayerSlot, bool, const char *, uint64);
-internal void Hook_ClientActive(CPlayerSlot slot, bool bLoadGame, const char *pszName, uint64 xuid);
+static_function void Hook_ClientActive(CPlayerSlot slot, bool bLoadGame, const char *pszName, uint64 xuid);
 
 SH_DECL_HOOK5_void(ISource2GameClients, ClientDisconnect, SH_NOATTRIB, false, CPlayerSlot, ENetworkDisconnectionReason, const char *, uint64,
 				   const char *);
-internal void Hook_ClientDisconnect(CPlayerSlot slot, ENetworkDisconnectionReason reason, const char *pszName, uint64 xuid, const char *pszNetworkID);
+static_function void Hook_ClientDisconnect(CPlayerSlot slot, ENetworkDisconnectionReason reason, const char *pszName, uint64 xuid,
+										   const char *pszNetworkID);
 
 SH_DECL_HOOK1_void(ISource2GameClients, ClientVoice, SH_NOATTRIB, false, CPlayerSlot);
-internal void Hook_ClientVoice(CPlayerSlot slot);
+static_function void Hook_ClientVoice(CPlayerSlot slot);
 
 SH_DECL_HOOK2_void(ISource2GameClients, ClientCommand, SH_NOATTRIB, false, CPlayerSlot, const CCommand &);
-internal void Hook_ClientCommand(CPlayerSlot slot, const CCommand &args);
+static_function void Hook_ClientCommand(CPlayerSlot slot, const CCommand &args);
 
 // INetworkServerService
 SH_DECL_HOOK3_void(INetworkServerService, StartupServer, SH_NOATTRIB, 0, const GameSessionConfiguration_t &, ISource2WorldSession *, const char *);
-internal void Hook_StartupServer(const GameSessionConfiguration_t &config, ISource2WorldSession *, const char *);
+static_function void Hook_StartupServer(const GameSessionConfiguration_t &config, ISource2WorldSession *, const char *);
 
 // IGameEventManager2
 SH_DECL_HOOK2(IGameEventManager2, FireEvent, SH_NOATTRIB, false, bool, IGameEvent *, bool);
-internal bool Hook_FireEvent(IGameEvent *event, bool bDontBroadcast);
+static_function bool Hook_FireEvent(IGameEvent *event, bool bDontBroadcast);
 
 // ICvar
 SH_DECL_HOOK3_void(ICvar, DispatchConCommand, SH_NOATTRIB, 0, ConCommandHandle, const CCommandContext &, const CCommand &);
-internal void Hook_DispatchConCommand(ConCommandHandle cmd, const CCommandContext &ctx, const CCommand &args);
+static_function void Hook_DispatchConCommand(ConCommandHandle cmd, const CCommandContext &ctx, const CCommand &args);
 
 // IGameEventSystem
 SH_DECL_HOOK8_void(IGameEventSystem, PostEventAbstract, SH_NOATTRIB, 0, CSplitScreenSlot, bool, int, const uint64 *, INetworkMessageInternal *,
 				   const CNetMessage *, unsigned long, NetChannelBufType_t);
-internal void Hook_PostEvent(CSplitScreenSlot nSlot, bool bLocalOnly, int nClientCount, const uint64 *clients, INetworkMessageInternal *pEvent,
-							 const CNetMessage *pData, unsigned long nSize, NetChannelBufType_t bufType);
+static_function void Hook_PostEvent(CSplitScreenSlot nSlot, bool bLocalOnly, int nClientCount, const uint64 *clients, INetworkMessageInternal *pEvent,
+									const CNetMessage *pData, unsigned long nSize, NetChannelBufType_t bufType);
 
 // CEntitySystem
 SH_DECL_HOOK2_void(CEntitySystem, Spawn, SH_NOATTRIB, false, int, const EntitySpawnInfo_t *);
-internal void Hook_CEntitySystem_Spawn_Post(int nCount, const EntitySpawnInfo_t *pInfo);
+static_function void Hook_CEntitySystem_Spawn_Post(int nCount, const EntitySpawnInfo_t *pInfo);
 
 // INetworkGameServer
-internal int activateServerHook {};
+static_global int activateServerHook {};
 SH_DECL_HOOK0(INetworkGameServer, ActivateServer, SH_NOATTRIB, false, bool);
-internal bool Hook_ActivateServer();
+static_function bool Hook_ActivateServer();
 
 // IGameSystem
-internal int serverGamePostSimulateHook {};
+static_global int serverGamePostSimulateHook {};
 SH_DECL_HOOK1_void(IGameSystem, ServerGamePostSimulate, SH_NOATTRIB, false, const EventServerGamePostSimulate_t *);
-internal void Hook_ServerGamePostSimulate(const EventServerGamePostSimulate_t *);
+static_function void Hook_ServerGamePostSimulate(const EventServerGamePostSimulate_t *);
 
-internal bool ignoreTouchEvent {};
+static_global bool ignoreTouchEvent {};
 
 void hooks::Initialize()
 {
@@ -200,7 +201,7 @@ void hooks::Cleanup()
 }
 
 // Entity hooks
-internal void AddEntityHooks(CBaseEntity *entity)
+static_function void AddEntityHooks(CBaseEntity *entity)
 {
 	if (!V_stricmp(entity->GetClassname(), "cs_player_controller") && !changeTeamHook)
 	{
@@ -225,7 +226,7 @@ internal void AddEntityHooks(CBaseEntity *entity)
 	}
 }
 
-internal void RemoveEntityHooks(CBaseEntity *entity)
+static_function void RemoveEntityHooks(CBaseEntity *entity)
 {
 	if (V_strstr(entity->GetClassname(), "trigger_") || !V_stricmp(entity->GetClassname(), "player"))
 	{
@@ -284,7 +285,7 @@ void hooks::HookEntities()
 }
 
 // CBaseEntity
-internal void Hook_OnStartTouch(CBaseEntity *pOther)
+static_function void Hook_OnStartTouch(CBaseEntity *pOther)
 {
 	CBaseEntity *pThis = META_IFACEPTR(CBaseEntity);
 	CCSPlayerPawn *pawn = NULL;
@@ -327,7 +328,7 @@ internal void Hook_OnStartTouch(CBaseEntity *pOther)
 	RETURN_META(MRES_IGNORED);
 }
 
-internal void Hook_OnStartTouchPost(CBaseEntity *pOther)
+static_function void Hook_OnStartTouchPost(CBaseEntity *pOther)
 {
 	if (ignoreTouchEvent)
 	{
@@ -362,7 +363,7 @@ internal void Hook_OnStartTouchPost(CBaseEntity *pOther)
 	RETURN_META(MRES_IGNORED);
 }
 
-internal void Hook_OnTouch(CBaseEntity *pOther)
+static_function void Hook_OnTouch(CBaseEntity *pOther)
 {
 	CBaseEntity *pThis = META_IFACEPTR(CBaseEntity);
 	CCSPlayerPawn *pawn = NULL;
@@ -402,7 +403,7 @@ internal void Hook_OnTouch(CBaseEntity *pOther)
 	RETURN_META(MRES_SUPERCEDE);
 }
 
-internal void Hook_OnTouchPost(CBaseEntity *pOther)
+static_function void Hook_OnTouchPost(CBaseEntity *pOther)
 {
 	if (ignoreTouchEvent)
 	{
@@ -413,7 +414,7 @@ internal void Hook_OnTouchPost(CBaseEntity *pOther)
 	RETURN_META(MRES_IGNORED);
 }
 
-internal void Hook_OnEndTouch(CBaseEntity *pOther)
+static_function void Hook_OnEndTouch(CBaseEntity *pOther)
 {
 	CBaseEntity *pThis = META_IFACEPTR(CBaseEntity);
 	CCSPlayerPawn *pawn = NULL;
@@ -457,7 +458,7 @@ internal void Hook_OnEndTouch(CBaseEntity *pOther)
 	RETURN_META(MRES_SUPERCEDE);
 }
 
-internal void Hook_OnEndTouchPost(CBaseEntity *pOther)
+static_function void Hook_OnEndTouchPost(CBaseEntity *pOther)
 {
 	if (ignoreTouchEvent)
 	{
@@ -484,7 +485,7 @@ internal void Hook_OnEndTouchPost(CBaseEntity *pOther)
 	RETURN_META(MRES_IGNORED);
 }
 
-internal void Hook_OnTeleport(const Vector *newPosition, const QAngle *newAngles, const Vector *newVelocity)
+static_function void Hook_OnTeleport(const Vector *newPosition, const QAngle *newAngles, const Vector *newVelocity)
 {
 	CBaseEntity *this_ = META_IFACEPTR(CBaseEntity);
 	// Just to be sure.
@@ -497,7 +498,7 @@ internal void Hook_OnTeleport(const Vector *newPosition, const QAngle *newAngles
 }
 
 // CCSPlayerController
-internal void Hook_OnChangeTeamPost(i32 team)
+static_function void Hook_OnChangeTeamPost(i32 team)
 {
 	CCSPlayerController *controller = META_IFACEPTR(CCSPlayerController);
 	MovementPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
@@ -508,18 +509,18 @@ internal void Hook_OnChangeTeamPost(i32 team)
 }
 
 // ISource2GameEntities
-internal void Hook_CheckTransmit(CCheckTransmitInfo **pInfo, int infoCount, CBitVec<16384> &, const Entity2Networkable_t **pNetworkables,
-								 const uint16 *pEntityIndicies, int nEntities, bool bEnablePVSBits)
+static_function void Hook_CheckTransmit(CCheckTransmitInfo **pInfo, int infoCount, CBitVec<16384> &, const Entity2Networkable_t **pNetworkables,
+										const uint16 *pEntityIndicies, int nEntities, bool bEnablePVSBits)
 {
 	KZ::quiet::OnCheckTransmit(pInfo, infoCount);
 	RETURN_META(MRES_IGNORED);
 }
 
 // ISource2Server
-internal void Hook_GameFrame(bool simulating, bool bFirstTick, bool bLastTick)
+static_function void Hook_GameFrame(bool simulating, bool bFirstTick, bool bLastTick)
 {
 	g_KZPlugin.serverGlobals = *(g_pKZUtils->GetGlobals());
-	local_persist int entitySystemHook {};
+	static_persist int entitySystemHook {};
 	if (GameEntitySystem() && !entitySystemHook)
 	{
 		entitySystemHook = SH_ADD_HOOK(CEntitySystem, Spawn, GameEntitySystem(), SH_STATIC(Hook_CEntitySystem_Spawn_Post), true);
@@ -527,38 +528,38 @@ internal void Hook_GameFrame(bool simulating, bool bFirstTick, bool bLastTick)
 	RETURN_META(MRES_IGNORED);
 }
 
-internal void Hook_GameServerSteamAPIActivated() {}
+static_function void Hook_GameServerSteamAPIActivated() {}
 
-internal void Hook_GameServerSteamAPIDeactivated() {}
+static_function void Hook_GameServerSteamAPIDeactivated() {}
 
 // ISource2GameClients
-internal bool Hook_ClientConnect(CPlayerSlot slot, const char *pszName, uint64 xuid, const char *pszNetworkID, bool unk1,
-								 CBufferString *pRejectReason)
+static_function bool Hook_ClientConnect(CPlayerSlot slot, const char *pszName, uint64 xuid, const char *pszNetworkID, bool unk1,
+										CBufferString *pRejectReason)
 {
 	g_pKZPlayerManager->OnClientConnect(slot, pszName, xuid, pszNetworkID, unk1, pRejectReason);
 	RETURN_META_VALUE(MRES_IGNORED, true);
 }
 
-internal void Hook_OnClientConnected(CPlayerSlot slot, const char *pszName, uint64 xuid, const char *pszNetworkID, const char *pszAddress,
-									 bool bFakePlayer)
+static_function void Hook_OnClientConnected(CPlayerSlot slot, const char *pszName, uint64 xuid, const char *pszNetworkID, const char *pszAddress,
+											bool bFakePlayer)
 {
 	g_pKZPlayerManager->OnClientConnected(slot, pszName, xuid, pszNetworkID, pszAddress, bFakePlayer);
 	RETURN_META(MRES_IGNORED);
 }
 
-internal void Hook_ClientFullyConnect(CPlayerSlot slot)
+static_function void Hook_ClientFullyConnect(CPlayerSlot slot)
 {
 	g_pKZPlayerManager->OnClientFullyConnect(slot);
 	RETURN_META(MRES_IGNORED);
 }
 
-internal void Hook_ClientPutInServer(CPlayerSlot slot, char const *pszName, int type, uint64 xuid)
+static_function void Hook_ClientPutInServer(CPlayerSlot slot, char const *pszName, int type, uint64 xuid)
 {
 	g_pKZPlayerManager->OnClientPutInServer(slot, pszName, type, xuid);
 	RETURN_META(MRES_IGNORED);
 }
 
-internal void Hook_ClientActive(CPlayerSlot slot, bool bLoadGame, const char *pszName, uint64 xuid)
+static_function void Hook_ClientActive(CPlayerSlot slot, bool bLoadGame, const char *pszName, uint64 xuid)
 {
 	g_pKZPlayerManager->OnClientActive(slot, bLoadGame, pszName, xuid);
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(slot);
@@ -573,7 +574,8 @@ internal void Hook_ClientActive(CPlayerSlot slot, bool bLoadGame, const char *ps
 	RETURN_META(MRES_IGNORED);
 }
 
-internal void Hook_ClientDisconnect(CPlayerSlot slot, ENetworkDisconnectionReason reason, const char *pszName, uint64 xuid, const char *pszNetworkID)
+static_function void Hook_ClientDisconnect(CPlayerSlot slot, ENetworkDisconnectionReason reason, const char *pszName, uint64 xuid,
+										   const char *pszNetworkID)
 {
 	g_pKZPlayerManager->OnClientDisconnect(slot, reason, pszName, xuid, pszNetworkID);
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(slot);
@@ -589,12 +591,12 @@ internal void Hook_ClientDisconnect(CPlayerSlot slot, ENetworkDisconnectionReaso
 	RETURN_META(MRES_IGNORED);
 }
 
-internal void Hook_ClientVoice(CPlayerSlot slot)
+static_function void Hook_ClientVoice(CPlayerSlot slot)
 {
 	g_pKZPlayerManager->OnClientVoice(slot);
 }
 
-internal void Hook_ClientCommand(CPlayerSlot slot, const CCommand &args)
+static_function void Hook_ClientCommand(CPlayerSlot slot, const CCommand &args)
 {
 	if (META_RES result = scmd::OnClientCommand(slot, args))
 	{
@@ -604,14 +606,14 @@ internal void Hook_ClientCommand(CPlayerSlot slot, const CCommand &args)
 }
 
 // INetworkServerService
-internal void Hook_StartupServer(const GameSessionConfiguration_t &config, ISource2WorldSession *, const char *)
+static_function void Hook_StartupServer(const GameSessionConfiguration_t &config, ISource2WorldSession *, const char *)
 {
 	g_KZPlugin.AddonInit();
 	RETURN_META(MRES_IGNORED);
 }
 
 // IGameEventManager2
-internal bool Hook_FireEvent(IGameEvent *event, bool bDontBroadcast)
+static_function bool Hook_FireEvent(IGameEvent *event, bool bDontBroadcast)
 {
 	if (event)
 	{
@@ -652,7 +654,7 @@ internal bool Hook_FireEvent(IGameEvent *event, bool bDontBroadcast)
 }
 
 // ICvar
-internal void Hook_DispatchConCommand(ConCommandHandle cmd, const CCommandContext &ctx, const CCommand &args)
+static_function void Hook_DispatchConCommand(ConCommandHandle cmd, const CCommandContext &ctx, const CCommand &args)
 {
 	META_RES mres = scmd::OnDispatchConCommand(cmd, ctx, args);
 
@@ -660,14 +662,14 @@ internal void Hook_DispatchConCommand(ConCommandHandle cmd, const CCommandContex
 }
 
 // IGameEventSystem
-internal void Hook_PostEvent(CSplitScreenSlot nSlot, bool bLocalOnly, int nClientCount, const uint64 *clients, INetworkMessageInternal *pEvent,
-							 const CNetMessage *pData, unsigned long nSize, NetChannelBufType_t bufType)
+static_function void Hook_PostEvent(CSplitScreenSlot nSlot, bool bLocalOnly, int nClientCount, const uint64 *clients, INetworkMessageInternal *pEvent,
+									const CNetMessage *pData, unsigned long nSize, NetChannelBufType_t bufType)
 {
 	KZ::quiet::OnPostEvent(pEvent, pData, clients);
 }
 
 // CEntitySystem
-internal void Hook_CEntitySystem_Spawn_Post(int nCount, const EntitySpawnInfo_t *pInfo_DontUse)
+static_function void Hook_CEntitySystem_Spawn_Post(int nCount, const EntitySpawnInfo_t *pInfo_DontUse)
 {
 	EntitySpawnInfo_t *pInfo = (EntitySpawnInfo_t *)pInfo_DontUse;
 
@@ -681,9 +683,9 @@ internal void Hook_CEntitySystem_Spawn_Post(int nCount, const EntitySpawnInfo_t 
 }
 
 // INetworkGameServer
-internal bool Hook_ActivateServer()
+static_function bool Hook_ActivateServer()
 {
-	local_persist bool infiniteAmmoUnlocked {};
+	static_persist bool infiniteAmmoUnlocked {};
 	if (!infiniteAmmoUnlocked)
 	{
 		infiniteAmmoUnlocked = true;
@@ -703,7 +705,7 @@ internal bool Hook_ActivateServer()
 }
 
 // IGameSystem
-internal void Hook_ServerGamePostSimulate(const EventServerGamePostSimulate_t *)
+static_function void Hook_ServerGamePostSimulate(const EventServerGamePostSimulate_t *)
 {
 	ProcessTimers();
 }

--- a/src/utils/simplecmds.cpp
+++ b/src/utils/simplecmds.cpp
@@ -25,10 +25,10 @@ struct ScmdManager
 	Scmd cmds[SCMD_MAX_CMDS];
 };
 
-internal ScmdManager g_cmdManager = {};
-internal bool g_coreCmdsRegistered = false;
+static_global ScmdManager g_cmdManager = {};
+static_global bool g_coreCmdsRegistered = false;
 
-internal SCMD_CALLBACK(Command_KzHelp)
+static_function SCMD_CALLBACK(Command_KzHelp)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
 	player->languageService->PrintChat(true, false, "Command Help Response (Chat)");
@@ -48,7 +48,7 @@ internal SCMD_CALLBACK(Command_KzHelp)
 	return MRES_SUPERCEDE;
 }
 
-internal void RegisterCoreCmds()
+static_function void RegisterCoreCmds()
 {
 	g_coreCmdsRegistered = true;
 

--- a/src/utils/utils_interface.cpp
+++ b/src/utils/utils_interface.cpp
@@ -112,6 +112,6 @@ CUtlVector<CServerSideClient *> *KZUtils::GetClientList()
 	{
 		return nullptr;
 	}
-	local_persist const int offset = g_pGameConfig->GetOffset("ClientOffset");
+	static_persist const int offset = g_pGameConfig->GetOffset("ClientOffset");
 	return (CUtlVector<CServerSideClient *> *)((char *)g_pNetworkServerService->GetIGameServer() + offset);
 }

--- a/src/utils/utils_print.cpp
+++ b/src/utils/utils_print.cpp
@@ -10,7 +10,7 @@
  * Credit to Szwagi
  */
 
-internal char ConvertColorStringToByte(const char *str, size_t length)
+static_function char ConvertColorStringToByte(const char *str, size_t length)
 {
 	switch (length)
 	{
@@ -108,12 +108,12 @@ struct CFormatContext
 	char *result_end;
 };
 
-internal bool HasEnoughSpace(const CFormatContext *ctx, uintptr_t space)
+static_function bool HasEnoughSpace(const CFormatContext *ctx, uintptr_t space)
 {
 	return (uintptr_t)(ctx->result_end - ctx->result) > space;
 }
 
-internal CFormatResult EscapeChars(CFormatContext *ctx)
+static_function CFormatResult EscapeChars(CFormatContext *ctx)
 {
 	if (*ctx->current == '{' && *(ctx->current + 1) == '{')
 	{
@@ -129,7 +129,7 @@ internal CFormatResult EscapeChars(CFormatContext *ctx)
 	return CFORMAT_NOT_US;
 }
 
-internal CFormatResult ParseColors(CFormatContext *ctx)
+static_function CFormatResult ParseColors(CFormatContext *ctx)
 {
 	const char *current = ctx->current;
 	if (*current == '{')
@@ -160,7 +160,7 @@ internal CFormatResult ParseColors(CFormatContext *ctx)
 	return CFORMAT_NOT_US;
 }
 
-internal CFormatResult ReplaceNewlines(CFormatContext *ctx)
+static_function CFormatResult ReplaceNewlines(CFormatContext *ctx)
 {
 	if (*ctx->current == '\n')
 	{
@@ -178,7 +178,7 @@ internal CFormatResult ReplaceNewlines(CFormatContext *ctx)
 	return CFORMAT_NOT_US;
 }
 
-internal CFormatResult AddSpace(CFormatContext *ctx)
+static_function CFormatResult AddSpace(CFormatContext *ctx)
 {
 	if (!HasEnoughSpace(ctx, 1))
 	{


### PR DESCRIPTION
`internal` has caused issues with 3rd party libraries, and the current aliases for `static` are a bit confusing.

This PR removes `internal` entirely and changes the names to something that makes more sense.

- global variables marked as `static` should be marked `static_global` instead
- global variables marked as `static` declared within a function scope should be marked `static_persist` instead
- free functions marked as `static` should be marked `static_function` instead
- class methods marked as `static` remain `static`