### PR TITLE
Russian translations

### DIFF
--- a/translations/cs2kz-commands.phrases.txt
+++ b/translations/cs2kz-commands.phrases.txt
@@ -250,30 +250,35 @@
 	"Command Description - kz_style"
 	{
 		"en"		"List, add, remove or toggle style."
+		"ru"		"Показать, добавить, удалить или переключить стиль."
 		"sv"		"Lista, lägg till, ta bort eller toggla style."
 		"ua"		"Показати, додати, прибрати або перемикнути стиль."
 	}
 	"Command Description - kz_addstyle"
 	{
 		"en"		"List or add style."
+		"ru"		"Показать или добавить стиль"
 		"sv"		"Lista eller lägg till style."
 		"ua"		"Показати або додати стиль."
 	}
 	"Command Description - kz_removestyle"
 	{
 		"en"		"List active styles or remove style."
+		"ru"		"Показать активные стили или удалить стиль."
 		"sv"		"Lista aktiva styles eller ta bort style."
 		"ua"		"Показати активні стилі або видалити стиль."
 	}
 	"Command Description - kz_togglestyle"
 	{
 		"en"		"List or toggle style."
+		"ru"		"Показать или переключить стиль."
 		"sv"		"Lista eller toggla style."
 		"ua"		"Показати або перемикнути стиль."
 	}
 	"Command Description - kz_clearstyles"
 	{
 		"en"		"Clear all styles."
+		"ru"		"Очистить все стили."
 		"sv"		"Rensa alla styles."
 		"ua"		"Очистити всі стилі."
 	}
@@ -394,6 +399,7 @@
 	"Command Description - kz_pb"
 	{
 		"en"		"Retrieve personal best statistics."
+		"ru"		"Показать личный рекорд."
 		"sv"		"Hämta personlig bästa statistik."
 		"ua"		"Показати персональний найкращий час."
 	}

--- a/translations/cs2kz-hud.phrases.txt
+++ b/translations/cs2kz-hud.phrases.txt
@@ -124,6 +124,7 @@
 	"HUD - HTML Panel Disabled"
 	{
 		"en"		"Panel disabled."
+		"ru"		"Панель отключена."
 		"sv"		"Panel inaktiverad."
 		"ua"		"Панель вимкнено."
 	}

--- a/translations/cs2kz-styles.phrases.txt
+++ b/translations/cs2kz-styles.phrases.txt
@@ -3,18 +3,21 @@
 	"Style Command Usage"
 	{
 		"en"		"{grey}Usage: {default}kz_style <style>/+<style>/-<style>{grey}. Check console for possible styles!"
+		"ru"		"{grey}Применение: {default}kz_style <style>/+<style>/-<style>{grey}. Проверьте консоль, чтобы увидеть список доступных стилей!"
 		"sv"		"{grey}Användande: {default}kz_style <style>/+<style>/-<style>{grey}. Kolla konsolen för möjliga styles!"
 		"ua"		"{grey}Використання: {default}kz_style <style>/+<style>/-<style>{grey}. Перевірте консоль, щоб побачити список доступних стилів!"
 	}
 	"Add Style Command Usage"
 	{
 		"en"		"{grey}Usage: {default}kz_addstyle <style>{grey}. Check console for possible styles!"
+		"ru"		"{grey}Применение: {default}kz_addstyle <style>{grey}. Проверьте консоль, чтобы увидеть список доступных стилей!"
 		"sv"		"{grey}Användande: {default}kz_addstyle <style>{grey}. Kolla konsolen för möjliga styles!"
 		"ua"		"{grey}Використання: {default}kz_addstyle <style>{grey}. Перевірте консоль, щоб побачити список доступних стилів!"
 	}
 	"Remove Style Command Usage"
 	{
 		"en"		"{grey}Usage: {default}kz_removestyle <style>{grey}. Check console for possible styles!"
+		"ru"		"{grey}Применение: {default}kz_removestyle <style>{grey}. Проверьте консоль, чтобы увидеть список доступных стилей!"
 		"sv"		"{grey}Användande: {default}kz_removestyle <style>{grey}. Kolla konsolen för möjliga styles!"
 		"ua"		"{grey}Використання: {default}kz_removestyle <style>{grey}. Перевірте консоль, щоб побачити список доступних стилів!"
 	}
@@ -30,6 +33,7 @@
 	"Current Styles"
 	{
 		"en"		"Currently active styles:"
+		"ru"		"Активные стили:"
 		"sv"		"Nuvarande aktiva styles:"
 		"ua"		"Поточні активні стилі:"
 	}
@@ -56,6 +60,7 @@
 	"Styles Cleared"
 	{
 		"en"		"{grey}You have cleared your styles."
+		"ru"		"{grey}Вы очистили свои стили."
 		"sv"		"{grey}Du har rensat dina styles."
 		"ua"		"{grey}Ви очистили свої стилі."
 	}
@@ -63,6 +68,7 @@
 	{
 		"#format"	"style:s"
 		"en"		"{grey}You have removed {purple}{style}{grey} style."
+		"ru"		"{grey}Вы удалили стиль {purple}{style}{grey}."
 		"sv"		"{grey}Du har tagit bort {purple}{style}{grey} style."
 		"ua"		"{grey}Ви видалили {purple}{style}{grey} стиль."
 	}
@@ -70,6 +76,7 @@
 	{
 		"#format"	"style:s"
 		"en"		"{grey}You have added {purple}{style}{grey} style."
+		"ru"		"{grey}Вы добавили стиль {purple}{style}{grey}."
 		"sv"		"{grey}Du har lagt till {purple}{style}{grey} style."
 		"ua"		"{grey}Ви додали {purple}{style}{grey} стиль."
 	}
@@ -77,6 +84,7 @@
 	{
 		"#format"	"style:s"
 		"en"		"{darkred}The {purple}{style}{darkred} style is already active."
+		"ru"		"{darkred}Стиль {purple}{style}{darkred} уже активен."
 		"sv"		"{purple}{style}{darkred} style är redan aktiv."
 		"ua"		"{darkred}{purple}{style}{darkred} стиль вже активний."
 	}
@@ -85,6 +93,7 @@
 		// The AutoBhop style is currently not available.
 		"#format"	"style:s"
 		"en"		"{darkred}The {purple}{style}{darkred} style is not active."
+		"ru"		"{darkred}Стиль {purple}{style}{darkred} не активен."
 		"sv"		"{purple}{style}{darkred} style är inte aktiv."
 		"ua"		"{darkred}{purple}{style}{darkred} стиль не активовано."
 	}
@@ -92,7 +101,8 @@
 	{
 		"#format"	"style:s,conflict_style:s"
 		"en"		"{darkred}Unable to add style {purple}{style}{darkred} as the conflicting style {purple}{conflict_style}{darkred} is active."
-		"en"		"{darkred}Det gick inte att lägga till style {purple}{style}{darkred} eftersom den konflikterande style {purple}{conflict_style}{darkred} är aktiv."
+		"ru"		"{darkred}Не удалось добавить стиль {purple}{style}{darkred}, поскольку конфликтный стиль {purple}{conflict_style}{darkred} сейчас активен."
+		"sv"		"{darkred}Det gick inte att lägga till style {purple}{style}{darkred} eftersom den konflikterande style {purple}{conflict_style}{darkred} är aktiv."
 		"ua"		"{darkred}Неможливо додати стиль {purple}{style}{darkred}, оскільки конфліктний стиль {purple}{conflict_style}{darkred} наразі активний."
 	}
 }

--- a/translations/cs2kz-timer.phrases.txt
+++ b/translations/cs2kz-timer.phrases.txt
@@ -26,6 +26,7 @@
 		//  (+12:34.56)
 		"#format"	"color:s,diff_text:s"
 		"en"		" ({color}{diff_text}{grey})"
+		"ru"		" ({color}{diff_text}{grey})"
 		"sv"		" ({color}{diff_text}{grey})"
 		"ua"		" ({color}{diff_text}{grey})"
 	}
@@ -35,6 +36,7 @@
 		// GameChaos finished "blocks2006" in 10:06.84 | VNL | PRO
 		"#format"	"player_name:s,course_name:s,time:s,mode_style_text:s,tp_count_text:s"
 		"en"		"{lime}{player_name} {grey}finished {default}{course_name}{grey} in {default}{time}{grey} | {mode_style_text} | {tp_count_text}"
+		"ru"		"{lime}{player_name} {grey}завершил {default}{course_name}{grey} за {default}{time}{grey} | {mode_style_text} | {tp_count_text}"
 		"sv"		"{lime}{player_name} {grey}klarade {default}{course_name}{grey} på {default}{time}{grey} | {mode_style_text} | {tp_count_text}"
 		"ua"		"{lime}{player_name} {grey}завершив {default}{course_name}{grey} за {default}{time}{grey} | {mode_style_text} | {tp_count_text}"
 	}
@@ -44,6 +46,7 @@
 		// Server: #1/24 Overall (-1:00.00)
 		"#format"	"rank:d,max_rank:d,pb_diff_text:s"
 		"en"		"{grey}Server: #{default}{rank}{grey}/{default}{max_rank}{grey} {yellow}Overall{grey}{pb_diff_text}"
+		"ru"		"{grey}Сервер: #{default}{rank}{grey}/{default}{max_rank}{grey} {yellow}Среди всех{grey}{pb_diff_text}"
 		"sv"		"{grey}Server: #{default}{rank}{grey}/{default}{max_rank}{grey} {yellow}Total{grey}{pb_diff_text}"
 		"ua"		"{grey}Сервер: #{default}{rank}{grey}/{default}{max_rank}{grey} {yellow}Загальний{grey}{pb_diff_text}"
 	}
@@ -52,6 +55,7 @@
 		// Server: #1/24 Overall (-1:00.00) | #1/10 PRO (-2:00.00)
 		"#format"	"rank:d,max_rank:d,pb_diff_text:s,rank_pro:d,max_rank_pro:d,pb_diff_text_pro:s"
 		"en"		"{grey}Server: #{default}{rank}{grey}/{default}{max_rank}{grey} {yellow}Overall{grey}{pb_diff_text} | #{rank_pro}/{max_rank_pro} {blue}PRO{grey}{pb_diff_text_pro}"
+		"en"		"{grey}Сервер: #{default}{rank}{grey}/{default}{max_rank}{grey} {yellow}Среди всех{grey}{pb_diff_text} | #{rank_pro}/{max_rank_pro} {blue}PRO{grey}{pb_diff_text_pro}"
 		"sv"		"{grey}Server: #{default}{rank}{grey}/{default}{max_rank}{grey} {yellow}Total{grey}{pb_diff_text} | #{rank_pro}/{max_rank_pro} {blue}PRO{grey}{pb_diff_text_pro}"
 		"ua"		"{grey}Сервер: #{default}{rank}{grey}/{default}{max_rank}{grey} {yellow}Загальний{grey}{pb_diff_text} | #{rank_pro}/{max_rank_pro} {blue}PRO{grey}{pb_diff_text_pro}"
 	}


### PR DESCRIPTION
also fixed "en" to "sv" in cs2kz-styles.phrases.txt swedish translation (line 105)