### PR TITLE
Reset yaw angle when using turnbinds

### DIFF
--- a/src/kz/kz.h
+++ b/src/kz/kz.h
@@ -132,6 +132,8 @@ public:
 private:
 	bool hideLegs {};
 	f64 lastTeleportTime {};
+	f32 lastValidYaw {};
+	bool oldUsingTurnbinds {};
 
 public:
 	KZAnticheatService *anticheatService {};
@@ -156,6 +158,7 @@ public:
 	KZTipService *tipService {};
 	KZTriggerService *triggerService {};
 
+	void DisableTurnbinds();
 	void EnableGodMode();
 
 	// Leg stuff

--- a/src/kz/kz_player.cpp
+++ b/src/kz/kz_player.cpp
@@ -18,6 +18,7 @@
 #include "tip/kz_tip.h"
 #include "trigger/kz_trigger.h"
 
+#include "sdk/datatypes.h"
 #include "sdk/entity/cbasetrigger.h"
 #include "vprof.h"
 #include "steam/isteamgameserver.h"
@@ -195,6 +196,7 @@ void KZPlayer::OnProcessMovement()
 	MovementPlayer::OnProcessMovement();
 	KZ::mode::ApplyModeSettings(this);
 
+	this->DisableTurnbinds();
 	this->modeService->OnProcessMovement();
 	FOR_EACH_VEC(this->styleServices, i)
 	{
@@ -715,6 +717,35 @@ void KZPlayer::OnTeleport(const Vector *origin, const QAngle *angles, const Vect
 	this->jumpstatsService->InvalidateJumpstats("Teleported");
 	this->modeService->OnTeleport(origin, angles, velocity);
 	this->timerService->OnTeleport(origin, angles, velocity);
+}
+
+void KZPlayer::DisableTurnbinds()
+{
+	CCSPlayerPawn *pawn = this->GetPlayerPawn();
+	if (!pawn)
+	{
+		return;
+	}
+	
+	// holding both doesn't do anything. xor(1, 1) == 0
+	bool usingTurnbinds = (this->IsButtonPressed(IN_TURNLEFT) ^ this->IsButtonPressed(IN_TURNRIGHT));
+	QAngle angles;
+	this->GetAngles(&angles);
+	if (usingTurnbinds)
+	{
+		angles.y = this->lastValidYaw;
+		// NOTE(GameChaos): Using SetAngles, which uses Teleport makes player movement really weird
+		g_pKZUtils->SnapViewAngles(pawn, angles);
+		if (!this->oldUsingTurnbinds)
+		{
+			this->languageService->PrintChat(true, false, "Turnbinds Disabled");
+		}
+	}
+	else
+	{
+		this->lastValidYaw = angles.y;
+	}
+	this->oldUsingTurnbinds = usingTurnbinds;
 }
 
 void KZPlayer::EnableGodMode()

--- a/src/kz/kz_player.cpp
+++ b/src/kz/kz_player.cpp
@@ -726,7 +726,7 @@ void KZPlayer::DisableTurnbinds()
 	{
 		return;
 	}
-	
+
 	// holding both doesn't do anything. xor(1, 1) == 0
 	bool usingTurnbinds = (this->IsButtonPressed(IN_TURNLEFT) ^ this->IsButtonPressed(IN_TURNRIGHT));
 	QAngle angles;

--- a/translations/cs2kz-timer.phrases.txt
+++ b/translations/cs2kz-timer.phrases.txt
@@ -278,6 +278,10 @@
 		"sv"		"{darkred}Jumpstat-området hittades inte på kartan!"
 		"ua"		"{darkred}Не знайдено зону тренування стрибків на даній мапі!"
 	}
+	"Turnbinds Disabled"
+	{
+		"en"		"{darkred}Turnbinds are disabled."
+	}
 	
 	// Split #1: 12:34.56 (+12.34) | SPB +12.12 | PRO SPB +23.45
 	"Course Split Reached"


### PR DESCRIPTION
When using a turnbind reset the yaw angle to the last known one that wasn't using turnbinds.