### PR TITLE
Fix race condition in WebSocket handshake

### DIFF
--- a/src/kz/global/kz_global.h
+++ b/src/kz/global/kz_global.h
@@ -119,6 +119,21 @@ private:
 	static inline ix::WebSocket *apiSocket {};
 
 	/**
+	 * Protects `handshakeInitiated`.
+	 */
+	static inline std::mutex handshakeLock {};
+
+	/**
+	 * Whether we already initiated the handshake
+	 */
+	static inline bool handshakeInitiated {};
+
+	/**
+	 * Used to wait for `handshakeInitiated` to become true
+	 */
+	static inline std::condition_variable handshakeCondvar {};
+
+	/**
 	 * Interval at which we need to send ping messages over the WebSocket.
 	 *
 	 * Set by the API during the handshake.


### PR DESCRIPTION
This fixes the issue of certain setups where the handshake is initiated before the map is loaded, causing it to fail. We now wait for a signal to be set by `OnActivateServer()` the first time a map is loaded.