### PR TITLE
Only initiate handshake if we know the current map

### DIFF
--- a/src/kz/global/kz_global.cpp
+++ b/src/kz/global/kz_global.cpp
@@ -148,6 +148,15 @@ void KZGlobalService::OnActivateServer()
 		KZGlobalService::Init();
 	}
 
+	bool ok = false;
+	CUtlString currentMapName = g_pKZUtils->GetCurrentMapName(&ok);
+
+	if (!ok)
+	{
+		META_CONPRINTF("[KZ::Global] Failed to get current map name. Cannot send `map-change` event.\n");
+		return;
+	}
+
 	{
 		std::unique_lock handshakeLock(KZGlobalService::handshakeLock);
 
@@ -157,15 +166,6 @@ void KZGlobalService::OnActivateServer()
 			KZGlobalService::handshakeCondvar.notify_one();
 			return;
 		}
-	}
-
-	bool ok = false;
-	CUtlString currentMapName = g_pKZUtils->GetCurrentMapName(&ok);
-
-	if (!ok)
-	{
-		META_CONPRINTF("[KZ::Global] Failed to get current map name. Cannot send `map-change` event.\n");
-		return;
 	}
 
 	KZ::API::events::MapChange data(currentMapName.Get());


### PR DESCRIPTION
There is a bug in #290 that checks the handshake status before trying to get the current map name. If we can't get the current map name, we shouldn't try to initiate the handshake yet. The next time we change map and _can_ get the name, we then handshake.

This PR depends on #291.