### PR TITLE
Delay API join events until the handshake is completed

### DIFF
--- a/src/kz/global/kz_global.h
+++ b/src/kz/global/kz_global.h
@@ -151,6 +151,12 @@ private:
 	static inline bool handshakeCompleted {};
 
 	/**
+	 * Whether we should reauthenticate existing players.
+	 * This happens if the API initializes after the players have connected.
+	 */
+	static inline std::atomic_bool shouldAuthenticateExistingPlayers = false;
+
+	/**
 	 * The ID to use for the next WebSocket message.
 	 */
 	static inline u64 nextMessageId = 1;


### PR DESCRIPTION
Fix crashes when the player joins too early. Resolve #296 and #297 hopefully
