### PR TITLE
Make everything more resistant against random WebSocket disconnects

### DIFF
--- a/src/kz/global/kz_global.cpp
+++ b/src/kz/global/kz_global.cpp
@@ -375,7 +375,7 @@ KZGlobalService::SubmitRecordResult KZGlobalService::SubmitRecord(u16 filterID, 
 	data.time = time;
 	data.metadata = metadata;
 
-	if (!KZGlobalService::IsConnected())
+	if (!KZGlobalService::IsConnected() && KZGlobalService::MightConnect())
 	{
 		std::unique_lock runQueueLock(KZGlobalService::runQueueMutex);
 		KZGlobalService::runQueue.emplace_back(std::move(data), std::move(cb));

--- a/src/kz/global/kz_global.h
+++ b/src/kz/global/kz_global.h
@@ -41,6 +41,19 @@ public:
 	}
 
 	/**
+	 * Returns whether we might connect to the API in the future.
+	 */
+	static bool MightConnect()
+	{
+		// clang-format off
+
+		return (KZGlobalService::apiSocket != nullptr)
+			&& (KZGlobalService::apiSocket->getReadyState() != ix::ReadyState::Open);
+
+		// clang-format on
+	}
+
+	/**
 	 * Executes the given function `f` with a pointer to the current map (if any).
 	 *
 	 * This function will lock access to the current map and therefore should complete quickly.

--- a/src/kz/timer/announce.cpp
+++ b/src/kz/timer/announce.cpp
@@ -148,9 +148,26 @@ void RecordAnnounce::SubmitGlobal()
 	};
 
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(this->userID);
+
 	// Dirty hack since nested forward declaration isn't possible.
-	this->global = player->globalService->SubmitRecord(this->globalFilterID, this->time, this->teleports, this->mode.md5, (void *)(&this->styles),
-													   this->metadata.c_str(), callback);
+	KZGlobalService::SubmitRecordResult submissionResult = player->globalService->SubmitRecord(
+		this->globalFilterID, this->time, this->teleports, this->mode.md5, (void *)(&this->styles), this->metadata.c_str(), callback);
+
+	switch (submissionResult)
+	{
+		case KZGlobalService::SubmitRecordResult::PlayerNotAuthenticated: /* fallthrough */
+		case KZGlobalService::SubmitRecordResult::MapNotGlobal:           /* fallthrough */
+		case KZGlobalService::SubmitRecordResult::Queued:
+		{
+			this->global = false;
+			break;
+		};
+		case KZGlobalService::SubmitRecordResult::Submitted:
+		{
+			this->global = true;
+			break;
+		};
+	}
 }
 
 void RecordAnnounce::UpdateGlobalCache()


### PR DESCRIPTION
This PR adds reconnects in case of "abnormal connection resets" (code 1006) which players have been experiencing a lot. As far as I can tell, this is out of our control, and the best thing we can do is try to reconnect in those cases. We also queue up runs that are submitted while disconnected, so that if we connect again later, the runs will still be submitted.