### PR TITLE
Fix potential crash in `PlayerManager::SteamIdToPlayer()`

### DIFF
--- a/src/player/player_manager.cpp
+++ b/src/player/player_manager.cpp
@@ -76,7 +76,7 @@ Player *PlayerManager::ToPlayer(CPlayerUserId userID)
 
 Player *PlayerManager::SteamIdToPlayer(u64 steamID, bool validated)
 {
-	for (size_t idx = 0; idx < sizeof(this->players); idx++)
+	for (size_t idx = 0; idx < Q_ARRAYSIZE(this->players); idx++)
 	{
 		if (this->players[idx]->GetSteamId64(validated) == steamID)
 		{


### PR DESCRIPTION
I used `sizeof()` incorrectly when calculating the upper bound for a loop. In the case of a player connecting and disconnecting before the API sends a `player-join-ack` event, the callback for that event will search the player list for the player that is now gone and go out of bounds, crashing the server.