### PR TITLE
Fix unintended global reconnections when unauthorized

### DIFF
--- a/src/kz/global/kz_global.cpp
+++ b/src/kz/global/kz_global.cpp
@@ -414,9 +414,9 @@ void KZGlobalService::OnWebSocketMessage(const ix::WebSocketMessagePtr &message)
 
 			switch (message->closeInfo.code)
 			{
-				case 1000 /* NORMAL */:
-				case 1001 /* GOING AWAY */:
-				case 1006 /* ABNORMAL */: /* fall-through */
+				case 1000 /* NORMAL */:     /* fall-through */
+				case 1001 /* GOING AWAY */: /* fall-through */
+				case 1006 /* ABNORMAL */:
 				{
 					KZGlobalService::socket->enableAutomaticReconnection();
 					KZGlobalService::state.store(KZGlobalService::State::DisconnectedButWorthRetrying);
@@ -430,6 +430,11 @@ void KZGlobalService::OnWebSocketMessage(const ix::WebSocketMessagePtr &message)
 					{
 						KZGlobalService::socket->enableAutomaticReconnection();
 						KZGlobalService::state.store(KZGlobalService::State::DisconnectedButWorthRetrying);
+					}
+					else
+					{
+						KZGlobalService::socket->disableAutomaticReconnection();
+						KZGlobalService::state.store(KZGlobalService::State::Disconnected);
 					}
 				}
 				break;


### PR DESCRIPTION
If we get rejected for a reason other than exceeding the heartbeat timeout, it's probably an issue that will persist, so we should stop trying to reconnect.