### PR TITLE
Changed JB Tiers

### DIFF
--- a/src/kz/mode/kz_mode_vnl.h
+++ b/src/kz/mode/kz_mode_vnl.h
@@ -12,7 +12,7 @@ class KZVanillaModeService : public KZModeService
 		{150.0f, 230.0f, 233.0f, 236.0f, 238.0f, 240.0f}, // WJ
 		{50.0f, 80.0f, 90.0f, 100.0f, 105.0f, 108.0f},    // LAJ
 		{215.0f, 250.0f, 253.0f, 255.0f, 258.0f, 261.0f}, // LAH
-		{215.0f, 255.0f, 265.0f, 270.0f, 273.0f, 275.0f}, // JB
+		{215.0f, 255.0f, 260.0f, 265.0f, 268.0f, 270.0f}, // JB
 	};
 
 	static inline CVValue_t modeCvarValues[] = {


### PR DESCRIPTION
Due to the height change for jbs from valve, the tiers for godlike, ownage, wrecker dont make much sense anymore.

Wrecker: 275 -> 270
Ownage: 273 -> 268
Godlike: 270 -> 265
Perfect: 265 -> 260
Impressive: 255 -> 255