### PR TITLE
Refactor beam and fix mapping API bug

### DIFF
--- a/src/kz/beam/kz_beam.h
+++ b/src/kz/beam/kz_beam.h
@@ -2,52 +2,6 @@
 #include "kz/kz.h"
 #include "tier1/circularbuffer.h"
 
-namespace KZ::beam
-{
-	constexpr int originHistorySize = 8;
-
-	struct BeamOrigin : public Vector
-	{
-		bool forceRecreate = false;
-	};
-
-	class BeamBuffer : public CFixedSizeCircularBuffer<BeamOrigin, originHistorySize>
-	{
-	public:
-		virtual void ElementAlloc(BeamOrigin &element) {};
-		virtual void ElementRelease(BeamOrigin &element) {};
-
-		void Clear()
-		{
-			Advance(originHistorySize);
-		}
-	};
-
-	struct PlayerBeam
-	{
-		CEntityHandle handle;
-		Vector lastOrigin;
-		bool moving = true;
-	};
-
-	struct InstantBeam
-	{
-		constexpr static i32 maxLingerTicks = 4;
-		CEntityHandle handle;
-		Vector start;
-		Vector end;
-		i32 tickRemaining;
-		i32 totalTicks;
-		i32 tickLingered = 0;
-	};
-
-	inline bool operator==(const InstantBeam &lhs, const InstantBeam &rhs)
-	{
-		return lhs.handle == rhs.handle;
-	}
-
-} // namespace KZ::beam
-
 class KZBeamService : public KZBaseService
 {
 public:
@@ -56,13 +10,13 @@ public:
 	virtual void Reset();
 	static void UpdateBeams();
 	void Update();
-	KZ::beam::PlayerBeam playerBeam;
-
+	CEntityHandle playerBeam;
+	CEntityHandle playerBeamNew;
 	static inline const Vector defaultOffset {0.0f, 0.0f, 1.75f};
 	Vector playerBeamOffset {defaultOffset};
 
 	KZPlayer *target {};
-	KZ::beam::BeamBuffer buffer;
+	bool validBeam {};
 
 	enum BeamType : u8
 	{
@@ -71,10 +25,6 @@ public:
 		BEAM_FEET,
 		BEAM_COUNT
 	} desiredBeamType;
-
-	i32 beamStopTick = 0;
-	bool canResumeBeam {};
-	i32 noclipTick = 0;
 
 	void SetBeamType(u8 type)
 	{
@@ -91,9 +41,4 @@ public:
 	}
 
 	void OnPlayerPreferencesLoaded();
-
-	CUtlVector<KZ::beam::InstantBeam> instantBeams;
-
-	void AddInstantBeam(const Vector &start, const Vector &end, u32 lifetime);
-	void UpdateInstantBeams();
 };

--- a/src/kz/measure/kz_measure.h
+++ b/src/kz/measure/kz_measure.h
@@ -26,12 +26,14 @@ public:
 	f32 startPosSetTime {};
 	MeasurePos startPos {};
 	f32 lastMeasureTime {};
+	CEntityHandle measurerHandle {};
 
 	virtual void Reset() override
 	{
 		startPosSetTime = {};
 		startPos.Invalidate();
 		lastMeasureTime = {};
+		measurerHandle = {};
 	}
 
 	void TryMeasure();
@@ -45,6 +47,4 @@ public:
 
 	// Calculates the minimum equivalent jumpstat distance to go between the two points
 	static f32 GetEffectiveDistance(Vector pointA, Vector pointB);
-
-	static void CalculateAdjustedBeamOrigins(const Vector &start, const Vector &end, Vector &adjustedStart, Vector &adjustedEnd);
 };

--- a/src/kz/tip/kz_tip.cpp
+++ b/src/kz/tip/kz_tip.cpp
@@ -146,16 +146,8 @@ void KZTipService::QueryBeamCvar()
 				{
 					return;
 				}
-				if (eStatus == ECvarValueStatus::ValueIntact && KZ_STREQI(pszCvarName, "0"))
-				{
-					player->languageService->PrintChat(true, false, "Beam Cvar Hint");
-				}
 		});
 		// clang-format on
-	}
-	else
-	{
-		this->player->languageService->PrintChat(true, false, "Beam Cvar Hint");
 	}
 }
 

--- a/src/kz/trigger/mapping_api.cpp
+++ b/src/kz/trigger/mapping_api.cpp
@@ -236,6 +236,11 @@ bool KZTriggerService::TouchTeleportTrigger(TriggerTouchTracker tracker)
 		this->player->SetVelocity(finalVelocity);
 	}
 
+	// We need to call teleport hook because we don't use teleport function directly.
+	if (this->player->processingMovement && this->player->currentMoveData)
+	{
+		this->player->OnTeleport(&finalOrigin, nullptr, nullptr);
+	}
 	this->player->SetOrigin(finalOrigin);
 
 	return true;

--- a/src/sdk/datatypes.h
+++ b/src/sdk/datatypes.h
@@ -39,8 +39,7 @@ enum MsgDest : int32_t
 	HUD_PRINTALERT = 6
 };
 
-
-enum InputBitMask_t : int64
+enum InputBitMask_t : uint64
 {
 	IN_NONE = 0x0,
 	IN_ALL = 0xffffffffffffffff,

--- a/src/sdk/datatypes.h
+++ b/src/sdk/datatypes.h
@@ -18,7 +18,7 @@ struct TransmitInfo
 	CBitVec<16384> *m_pTransmitEdict;
 };
 
-enum ObserverMode_t : uint8_t
+enum ObserverMode_t : uint32
 {
 	OBS_MODE_NONE = 0x0,
 	OBS_MODE_FIXED = 0x1,
@@ -39,7 +39,8 @@ enum MsgDest : int32_t
 	HUD_PRINTALERT = 6
 };
 
-enum InputBitMask_t : uint64_t
+
+enum InputBitMask_t : int64
 {
 	IN_NONE = 0x0,
 	IN_ALL = 0xffffffffffffffff,

--- a/src/sdk/entity/cparticlesystem.h
+++ b/src/sdk/entity/cparticlesystem.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "cbasemodelentity.h"
+
+class CParticleSystem : public CBaseModelEntity
+{
+public:
+	DECLARE_SCHEMA_CLASS(CParticleSystem)
+
+	SCHEMA_FIELD_POINTER(char, m_szSnapshotFileName)
+	SCHEMA_FIELD(bool, m_bActive)
+	SCHEMA_FIELD(bool, m_bFrozen)
+	SCHEMA_FIELD(float32, m_flFreezeTransitionDuration)
+	SCHEMA_FIELD(int32, m_nStopType)
+	SCHEMA_FIELD(bool, m_bAnimateDuringGameplayPause)
+	SCHEMA_FIELD(GameTime_t, m_flStartTime)
+	SCHEMA_FIELD(float32, m_flPreSimTime)
+	SCHEMA_FIELD_POINTER(Vector, m_vServerControlPoints)
+	SCHEMA_FIELD_POINTER(uint8, m_iServerControlPointAssignments)
+	SCHEMA_FIELD_POINTER(CHandle<CBaseEntity>, m_hControlPointEnts)
+	SCHEMA_FIELD(bool, m_bNoSave)
+	SCHEMA_FIELD(bool, m_bNoFreeze)
+	SCHEMA_FIELD(bool, m_bNoRamp)
+	SCHEMA_FIELD(bool, m_bStartActive)
+	SCHEMA_FIELD(CUtlSymbolLarge, m_iszEffectName)
+	SCHEMA_FIELD_POINTER(CUtlSymbolLarge, m_iszControlPointNames)
+	SCHEMA_FIELD(int32, m_nDataCP)
+	SCHEMA_FIELD(Vector, m_vecDataCPValue)
+	SCHEMA_FIELD(int32, m_nTintCP)
+	SCHEMA_FIELD(Color, m_clrTint)
+};
+
+#define CUSTOM_PARTICLE_SYSTEM_TEAM 5

--- a/src/utils/hooks.cpp
+++ b/src/utils/hooks.cpp
@@ -717,6 +717,8 @@ static_function void Hook_BuildGameSessionManifest(const EventBuildGameSessionMa
 		Warning("[CS2KZ] Precache kz soundevents \n");
 		pResourceManifest->AddResource(KZ_WORKSHOP_ADDON_SNDEVENT_FILE);
 	}
+	pResourceManifest->AddResource("particles/ui/hud/ui_map_def_utility_trail.vpcf");
+	pResourceManifest->AddResource("particles/ui/annotation/ui_annotation_line_segment.vpcf");
 }
 
 static_function ILoadingSpawnGroup *Hook_OnCreateLoadingSpawnGroupHook(SpawnGroupHandle_t hSpawnGroup, bool bSynchronouslySpawnEntities,

--- a/translations/cs2kz-beam.phrases.txt
+++ b/translations/cs2kz-beam.phrases.txt
@@ -45,11 +45,4 @@
 		"ua"		"{grey}Поточне зміщення променя: {x:.2f} {y:.2f} {z:.2f}"
 	}
 
-	"Beam Cvar Hint"
-	{
-		// Note: The spec_show_xray cvar needs to be set to 1 for beams to be visible.
-		"en"		"{blue}Note{grey}: The {default}spec_show_xray{grey} cvar needs to be set to {default}1{grey} for beams to be visible."
-		"sv"		"{blue}Obs:{grey}: Cvar-värdet {default}spec_show_xray{grey} måste vara inställt på {default}1{grey} för att strålarna ska synas."
-		"ua"		"{blue}Примітка{grey}: Для того, щоб промені були видимими, параметр {default}spec_show_xray{grey} повинен бути встановлений на {default}1{grey}."
-	}
 }


### PR DESCRIPTION
- Use `info_particle_system` instead of grenades for beams to remove `spec_show_xray` dependency.
  - The new particles only last for 4 seconds, so a new beam is created every time the old beam is going to expire
- Fix `!beam <type> not working
- Fix mapping API teleports not triggering teleport hook