### PR TITLE
Remove OnSetupMove override from kz_mode_vnl.h

### DIFF
--- a/src/kz/mode/kz_mode_vnl.h
+++ b/src/kz/mode/kz_mode_vnl.h
@@ -66,7 +66,6 @@ public:
 	virtual const CVValue_t *GetModeConVarValues() override;
 
 	// Triggerfix
-	virtual void OnSetupMove(PlayerCommand *pc) override;
 	virtual void OnPlayerMove() override;
 	virtual void OnProcessMovementPost() override;
 	virtual void OnDuckPost() override;


### PR DESCRIPTION
The implementation of this override was deleted in 825186cdbad22aa777f660f8a9f18f70134f591b

Remove declaration from header to avoid linker errors:
```
error LNK2001: unresolved external symbol "public: virtual void __cdecl KZVanillaModeService::OnSetupMove(class PlayerCommand *)" (?OnSetupMove@KZVanillaModeService@@UEAAXPEAVPlayerCommand@@@Z)
```