### PR TITLE
fix incorrect map rank

### DIFF
--- a/src/kz/db/queries/personal_best.h
+++ b/src/kz/db/queries/personal_best.h
@@ -27,7 +27,7 @@ constexpr char sql_getpbpro[] = R"(
 // The following queries should have no style!
 
 constexpr char sql_getmaprank[] = R"(
-    SELECT COUNT(DISTINCT Times.SteamID64) 
+    SELECT COUNT(DISTINCT Times.SteamID64) + 1
         FROM Times 
         INNER JOIN MapCourses ON MapCourses.ID=Times.MapCourseID 
         INNER JOIN Maps ON Maps.ID = MapCourses.MapID
@@ -40,12 +40,11 @@ constexpr char sql_getmaprank[] = R"(
             INNER JOIN Maps ON Maps.ID = MapCourses.MapID
             INNER JOIN Players ON Players.SteamID64=Times.SteamID64 
             WHERE Players.Cheater=0 AND Times.SteamID64=%llu AND Maps.Name='%s'
-            AND MapCourses.Name='%s' AND Times.ModeID=%d AND Times.StyleIDFlags=0) 
-    + 1
+            AND MapCourses.Name='%s' AND Times.ModeID=%d AND Times.StyleIDFlags=0)
 )";
 
 constexpr char sql_getmaprankpro[] = R"(
-    SELECT COUNT(DISTINCT Times.SteamID64) 
+    SELECT COUNT(DISTINCT Times.SteamID64) + 1
         FROM Times 
         INNER JOIN MapCourses ON MapCourses.ID=Times.MapCourseID 
         INNER JOIN Maps ON Maps.ID = MapCourses.MapID
@@ -60,8 +59,7 @@ constexpr char sql_getmaprankpro[] = R"(
             INNER JOIN Players ON Players.SteamID64=Times.SteamID64 
             WHERE Players.Cheater=0 AND Times.SteamID64=%llu AND Maps.Name='%s' 
             AND MapCourses.Name='%s' AND Times.ModeID=%d 
-            AND Times.StyleIDFlags=0 AND Times.Teleports=0) 
-    + 1
+            AND Times.StyleIDFlags=0 AND Times.Teleports=0)
 )";
 
 constexpr char sql_getlowestmaprank[] = R"(

--- a/src/kz/db/queries/save_time.h
+++ b/src/kz/db/queries/save_time.h
@@ -23,7 +23,7 @@ constexpr char sql_getpbpro[] = R"(
 // The following queries should have no style!
 
 constexpr char sql_getmaprank[] = R"(
-    SELECT COUNT(DISTINCT Times.SteamID64) 
+    SELECT COUNT(DISTINCT Times.SteamID64) + 1
         FROM Times 
         INNER JOIN Players ON Players.SteamID64=Times.SteamID64 
         WHERE Players.Cheater=0 AND Times.MapCourseID=%d
@@ -32,12 +32,11 @@ constexpr char sql_getmaprank[] = R"(
         FROM Times 
         INNER JOIN Players ON Players.SteamID64=Times.SteamID64 
         WHERE Players.Cheater=0 AND Times.SteamID64=%llu AND Times.MapCourseID=%d
-        AND Times.ModeID=%d AND Times.StyleIDFlags=0) 
-    + 1
+        AND Times.ModeID=%d AND Times.StyleIDFlags=0)
 )";
 
 constexpr char sql_getmaprankpro[] = R"(
-    SELECT COUNT(DISTINCT Times.SteamID64) 
+    SELECT COUNT(DISTINCT Times.SteamID64) + 1
         FROM Times 
         INNER JOIN Players ON Players.SteamID64=Times.SteamID64 
         WHERE Players.Cheater=0 AND Times.MapCourseID=%d
@@ -48,8 +47,7 @@ constexpr char sql_getmaprankpro[] = R"(
         INNER JOIN Players ON Players.SteamID64=Times.SteamID64 
         WHERE Players.Cheater=0 AND Times.SteamID64=%llu 
         AND Times.MapCourseID=%d AND Times.ModeID=%d 
-        AND Times.StyleIDFlags=0 AND Times.Teleports=0) 
-    + 1
+        AND Times.StyleIDFlags=0 AND Times.Teleports=0)
 )";
 
 constexpr char sql_getlowestmaprank[] = R"(


### PR DESCRIPTION
the trailing +1 for map rank applied to the Times.RunTime comparison instead of simply incrementing the rank#