### PR TITLE
Add compact panel

### DIFF
--- a/src/kz/hud/kz_hud.cpp
+++ b/src/kz/hud/kz_hud.cpp
@@ -157,14 +157,15 @@ void KZHUDService::DrawPanels(KZPlayer *player, KZPlayer *target)
 	std::string timerText = player->hudService->GetTimerText(language);
 	std::string speedText = player->hudService->GetSpeedText(language);
 
-	// clang-format off
 	bool compact = target->hudService->IsCompactPanel();
-	std::string centerText = KZLanguageService::PrepareMessageWithLang(language, compact ? "HUD - Center Text (Compact)" : "HUD - Center Text", 
+	// clang-format off
+	std::string centerText = compact ? "" : KZLanguageService::PrepareMessageWithLang(language, "HUD - Center Text",
 		keyText.c_str(), checkpointText.c_str(), timerText.c_str(), speedText.c_str());
 	std::string alertText = KZLanguageService::PrepareMessageWithLang(language, "HUD - Alert Text", 
 		keyText.c_str(), checkpointText.c_str(), timerText.c_str(), speedText.c_str());
-	std::string htmlText = KZLanguageService::PrepareMessageWithLang(language, compact ? "HUD - Html Center Text (Compact)" : "HUD - Html Center Text",
-		keyText.c_str(), checkpointText.c_str(), timerText.c_str(), speedText.c_str());
+	std::string htmlText = compact ? timerText + "<br>" + speedText
+		: KZLanguageService::PrepareMessageWithLang(language, "HUD - Html Center Text",
+			keyText.c_str(), checkpointText.c_str(), timerText.c_str(), speedText.c_str());
 	// clang-format on
 
 	centerText = centerText.substr(0, centerText.find_last_not_of('\n') + 1);

--- a/src/kz/hud/kz_hud.cpp
+++ b/src/kz/hud/kz_hud.cpp
@@ -163,7 +163,7 @@ void KZHUDService::DrawPanels(KZPlayer *player, KZPlayer *target)
 		keyText.c_str(), checkpointText.c_str(), timerText.c_str(), speedText.c_str());
 	std::string alertText = KZLanguageService::PrepareMessageWithLang(language, "HUD - Alert Text", 
 		keyText.c_str(), checkpointText.c_str(), timerText.c_str(), speedText.c_str());
-	std::string htmlText = compact ? timerText + "<br>" + speedText
+	std::string htmlText = compact ? (timerText.empty() ? speedText : timerText + "<br>" + speedText)
 		: KZLanguageService::PrepareMessageWithLang(language, "HUD - Html Center Text",
 			keyText.c_str(), checkpointText.c_str(), timerText.c_str(), speedText.c_str());
 	// clang-format on
@@ -239,6 +239,27 @@ void KZHUDService::ToggleCompactPanel()
 SCMD(kz_panel, SCFL_HUD)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
+	if (args->ArgC() >= 2)
+	{
+		if (KZ_STREQI(args->Arg(1), "compact"))
+		{
+			player->hudService->ToggleCompactPanel();
+			if (player->hudService->IsCompactPanel())
+			{
+				player->languageService->PrintChat(true, false, "HUD Option - Compact Panel - Enable");
+			}
+			else
+			{
+				player->languageService->PrintChat(true, false, "HUD Option - Compact Panel - Disable");
+			}
+			return MRES_SUPERCEDE;
+		}
+		else
+		{
+			player->languageService->PrintChat(true, false, "Panel Command Usage");
+			return MRES_SUPERCEDE;
+		}
+	}
 	player->hudService->TogglePanel();
 	if (player->hudService->IsShowingPanel())
 	{
@@ -247,21 +268,6 @@ SCMD(kz_panel, SCFL_HUD)
 	else
 	{
 		player->languageService->PrintChat(true, false, "HUD Option - Info Panel - Disable");
-	}
-	return MRES_SUPERCEDE;
-}
-
-SCMD(kz_panel_compact, SCFL_HUD)
-{
-	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
-	player->hudService->ToggleCompactPanel();
-	if (player->hudService->IsCompactPanel())
-	{
-		player->languageService->PrintChat(true, false, "HUD Option - Compact Panel - Enable");
-	}
-	else
-	{
-		player->languageService->PrintChat(true, false, "HUD Option - Compact Panel - Disable");
 	}
 	return MRES_SUPERCEDE;
 }

--- a/src/kz/hud/kz_hud.cpp
+++ b/src/kz/hud/kz_hud.cpp
@@ -26,7 +26,6 @@ static_global class KZOptionServiceEventListener_HUD : public KZOptionServiceEve
 	virtual void OnPlayerPreferencesLoaded(KZPlayer *player)
 	{
 		player->hudService->ResetShowPanel();
-		player->hudService->ResetCompactPanel();
 	}
 } optionEventListener;
 
@@ -39,7 +38,6 @@ void KZHUDService::Init()
 void KZHUDService::Reset()
 {
 	this->showPanel = this->player->optionService->GetPreferenceBool("showPanel", true);
-	this->compactPanel = this->player->optionService->GetPreferenceBool("compactPanel", false);
 	this->timerStoppedTime = {};
 	this->currentTimeWhenTimerStopped = {};
 }
@@ -192,11 +190,6 @@ void KZHUDService::ResetShowPanel()
 	this->showPanel = this->player->optionService->GetPreferenceBool("showPanel", true);
 }
 
-void KZHUDService::ResetCompactPanel()
-{
-	this->compactPanel = this->player->optionService->GetPreferenceBool("compactPanel", false);
-}
-
 void KZHUDService::TogglePanel()
 {
 	this->showPanel = !this->showPanel;
@@ -230,10 +223,14 @@ void KZTimerServiceEventListener_HUD::OnTimerEndPost(KZPlayer *player, u32 cours
 	player->hudService->OnTimerStopped(time);
 }
 
+bool KZHUDService::IsCompactPanel()
+{
+	return this->player->optionService->GetPreferenceBool("compactPanel");
+}
+
 void KZHUDService::ToggleCompactPanel()
 {
-	this->compactPanel = !this->compactPanel;
-	this->player->optionService->SetPreferenceBool("compactPanel", this->compactPanel);
+	this->player->optionService->SetPreferenceBool("compactPanel", !this->IsCompactPanel());
 }
 
 SCMD(kz_panel, SCFL_HUD)

--- a/src/kz/hud/kz_hud.cpp
+++ b/src/kz/hud/kz_hud.cpp
@@ -26,6 +26,7 @@ static_global class KZOptionServiceEventListener_HUD : public KZOptionServiceEve
 	virtual void OnPlayerPreferencesLoaded(KZPlayer *player)
 	{
 		player->hudService->ResetShowPanel();
+		player->hudService->ResetCompactPanel();
 	}
 } optionEventListener;
 
@@ -38,6 +39,7 @@ void KZHUDService::Init()
 void KZHUDService::Reset()
 {
 	this->showPanel = this->player->optionService->GetPreferenceBool("showPanel", true);
+	this->compactPanel = this->player->optionService->GetPreferenceBool("compactPanel", false);
 	this->timerStoppedTime = {};
 	this->currentTimeWhenTimerStopped = {};
 }
@@ -156,13 +158,13 @@ void KZHUDService::DrawPanels(KZPlayer *player, KZPlayer *target)
 	std::string speedText = player->hudService->GetSpeedText(language);
 
 	// clang-format off
-	std::string centerText = KZLanguageService::PrepareMessageWithLang(language, "HUD - Center Text", 
+	bool compact = target->hudService->IsCompactPanel();
+	std::string centerText = KZLanguageService::PrepareMessageWithLang(language, compact ? "HUD - Center Text (Compact)" : "HUD - Center Text", 
 		keyText.c_str(), checkpointText.c_str(), timerText.c_str(), speedText.c_str());
 	std::string alertText = KZLanguageService::PrepareMessageWithLang(language, "HUD - Alert Text", 
 		keyText.c_str(), checkpointText.c_str(), timerText.c_str(), speedText.c_str());
-	std::string htmlText = KZLanguageService::PrepareMessageWithLang(language, "HUD - Html Center Text",
+	std::string htmlText = KZLanguageService::PrepareMessageWithLang(language, compact ? "HUD - Html Center Text (Compact)" : "HUD - Html Center Text",
 		keyText.c_str(), checkpointText.c_str(), timerText.c_str(), speedText.c_str());
-
 	// clang-format on
 
 	centerText = centerText.substr(0, centerText.find_last_not_of('\n') + 1);
@@ -187,6 +189,11 @@ void KZHUDService::DrawPanels(KZPlayer *player, KZPlayer *target)
 void KZHUDService::ResetShowPanel()
 {
 	this->showPanel = this->player->optionService->GetPreferenceBool("showPanel", true);
+}
+
+void KZHUDService::ResetCompactPanel()
+{
+	this->compactPanel = this->player->optionService->GetPreferenceBool("compactPanel", false);
 }
 
 void KZHUDService::TogglePanel()
@@ -222,6 +229,12 @@ void KZTimerServiceEventListener_HUD::OnTimerEndPost(KZPlayer *player, u32 cours
 	player->hudService->OnTimerStopped(time);
 }
 
+void KZHUDService::ToggleCompactPanel()
+{
+	this->compactPanel = !this->compactPanel;
+	this->player->optionService->SetPreferenceBool("compactPanel", this->compactPanel);
+}
+
 SCMD(kz_panel, SCFL_HUD)
 {
 	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
@@ -233,6 +246,21 @@ SCMD(kz_panel, SCFL_HUD)
 	else
 	{
 		player->languageService->PrintChat(true, false, "HUD Option - Info Panel - Disable");
+	}
+	return MRES_SUPERCEDE;
+}
+
+SCMD(kz_panel_compact, SCFL_HUD)
+{
+	KZPlayer *player = g_pKZPlayerManager->ToPlayer(controller);
+	player->hudService->ToggleCompactPanel();
+	if (player->hudService->IsCompactPanel())
+	{
+		player->languageService->PrintChat(true, false, "HUD Option - Compact Panel - Enable");
+	}
+	else
+	{
+		player->languageService->PrintChat(true, false, "HUD Option - Compact Panel - Disable");
 	}
 	return MRES_SUPERCEDE;
 }

--- a/src/kz/hud/kz_hud.h
+++ b/src/kz/hud/kz_hud.h
@@ -13,7 +13,6 @@ private:
 	bool fromDuckbug {};
 	bool crouchJumping {};
 	bool showPanel {};
-	bool compactPanel {};
 	f64 timerStoppedTime {};
 	f64 currentTimeWhenTimerStopped {};
 
@@ -26,7 +25,6 @@ public:
 
 	void ResetShowPanel();
 	void TogglePanel();
-	void ResetCompactPanel();
 	void ToggleCompactPanel();
 
 	void OnPhysicsSimulate()
@@ -71,10 +69,7 @@ public:
 		return this->showPanel;
 	}
 
-	bool IsCompactPanel()
-	{
-		return this->compactPanel;
-	}
+	bool IsCompactPanel();
 
 	void OnTimerStopped(f64 currentTimeWhenTimerStopped);
 

--- a/src/kz/hud/kz_hud.h
+++ b/src/kz/hud/kz_hud.h
@@ -13,6 +13,7 @@ private:
 	bool fromDuckbug {};
 	bool crouchJumping {};
 	bool showPanel {};
+	bool compactPanel {};
 	f64 timerStoppedTime {};
 	f64 currentTimeWhenTimerStopped {};
 
@@ -25,6 +26,8 @@ public:
 
 	void ResetShowPanel();
 	void TogglePanel();
+	void ResetCompactPanel();
+	void ToggleCompactPanel();
 
 	void OnPhysicsSimulate()
 	{
@@ -66,6 +69,11 @@ public:
 	bool IsShowingPanel()
 	{
 		return this->showPanel;
+	}
+
+	bool IsCompactPanel()
+	{
+		return this->compactPanel;
 	}
 
 	void OnTimerStopped(f64 currentTimeWhenTimerStopped);

--- a/translations/cs2kz-commands.phrases.txt
+++ b/translations/cs2kz-commands.phrases.txt
@@ -498,6 +498,10 @@
 		"ko"		"중앙 패널 표시를 전환합니다."
 		"lv"		"Ieslēgt/izslēgt centrālā paneļa attēlošanu."
 	}
+	"Command Description - kz_panel_compact"
+	{
+		"en"		"Toggle compact centre panel (shows only time and speed)."
+	}
 	"Command Description - kz_jsbroadcast"
 	{
 		"en"		"Change jumpstats minimum threshold for broadcasting."

--- a/translations/cs2kz-commands.phrases.txt
+++ b/translations/cs2kz-commands.phrases.txt
@@ -498,10 +498,6 @@
 		"ko"		"중앙 패널 표시를 전환합니다."
 		"lv"		"Ieslēgt/izslēgt centrālā paneļa attēlošanu."
 	}
-	"Command Description - kz_panel_compact"
-	{
-		"en"		"Toggle compact centre panel (shows only time and speed)."
-	}
 	"Command Description - kz_jsbroadcast"
 	{
 		"en"		"Change jumpstats minimum threshold for broadcasting."

--- a/translations/cs2kz-hud.phrases.txt
+++ b/translations/cs2kz-hud.phrases.txt
@@ -199,45 +199,6 @@
 		"ko"		"{speed_text}<br>{key_text}"
 		"lv"		"{speed_text}<br>{key_text}"
 	}
-	"HUD - Center Text (Compact)"
-	{
-		// Compact mode: unused, timer + speed shown in HTML Center Text
-		"#format"	"key_text:s,checkpoint_text:s,timer_text:s,speed_text:s"
-		"en"		""
-		"chi"		""
-		"pl"		""
-		"ru"		""
-		"fi"		""
-		"sv"		""
-		"ua"		""
-		"tr"		""
-		"it"		""
-		"es"		""
-		"de"		""
-		"ko"		""
-		"lv"		""
-	}
-	"HUD - Html Center Text (Compact)"
-	{
-		// Compact mode:
-		// 01:23:45
-		// Speed: 234 (200)
-		"#format"	"key_text:s,checkpoint_text:s,timer_text:s,speed_text:s"
-		"en"		"{timer_text}<br>{speed_text}"
-		"chi"		"{timer_text}<br>{speed_text}"
-		"pl"		"{timer_text}<br>{speed_text}"
-		"ru"		"{timer_text}<br>{speed_text}"
-		"fi"		"{timer_text}<br>{speed_text}"
-		"sv"		"{timer_text}<br>{speed_text}"
-		"ua"		"{timer_text}<br>{speed_text}"
-		"tr"		"{timer_text}<br>{speed_text}"
-		"it"		"{timer_text}<br>{speed_text}"
-		"es"		"{timer_text}<br>{speed_text}"
-		"de"		"{timer_text}<br>{speed_text}"
-		"ko"		"{timer_text}<br>{speed_text}"
-		"lv"		"{timer_text}<br>{speed_text}"
-	}
-
 	"HUD - HTML Panel Disabled"
 	{
 		"en"		"Panel disabled."

--- a/translations/cs2kz-hud.phrases.txt
+++ b/translations/cs2kz-hud.phrases.txt
@@ -199,6 +199,7 @@
 		"ko"		"{speed_text}<br>{key_text}"
 		"lv"		"{speed_text}<br>{key_text}"
 	}
+
 	"HUD - HTML Panel Disabled"
 	{
 		"en"		"Panel disabled."

--- a/translations/cs2kz-hud.phrases.txt
+++ b/translations/cs2kz-hud.phrases.txt
@@ -256,4 +256,8 @@
 	{
 		"en"		"{grey}Compact panel disabled."
 	}
+	"Panel Command Usage"
+	{
+		"en"		"{grey}Usage: {default}kz_panel <compact>{grey}."
+	}
 }

--- a/translations/cs2kz-hud.phrases.txt
+++ b/translations/cs2kz-hud.phrases.txt
@@ -199,6 +199,44 @@
 		"ko"		"{speed_text}<br>{key_text}"
 		"lv"		"{speed_text}<br>{key_text}"
 	}
+	"HUD - Center Text (Compact)"
+	{
+		// Compact mode: unused, timer + speed shown in HTML Center Text
+		"#format"	"key_text:s,checkpoint_text:s,timer_text:s,speed_text:s"
+		"en"		""
+		"chi"		""
+		"pl"		""
+		"ru"		""
+		"fi"		""
+		"sv"		""
+		"ua"		""
+		"tr"		""
+		"it"		""
+		"es"		""
+		"de"		""
+		"ko"		""
+		"lv"		""
+	}
+	"HUD - Html Center Text (Compact)"
+	{
+		// Compact mode:
+		// 01:23:45
+		// Speed: 234 (200)
+		"#format"	"key_text:s,checkpoint_text:s,timer_text:s,speed_text:s"
+		"en"		"{timer_text}<br>{speed_text}"
+		"chi"		"{timer_text}<br>{speed_text}"
+		"pl"		"{timer_text}<br>{speed_text}"
+		"ru"		"{timer_text}<br>{speed_text}"
+		"fi"		"{timer_text}<br>{speed_text}"
+		"sv"		"{timer_text}<br>{speed_text}"
+		"ua"		"{timer_text}<br>{speed_text}"
+		"tr"		"{timer_text}<br>{speed_text}"
+		"it"		"{timer_text}<br>{speed_text}"
+		"es"		"{timer_text}<br>{speed_text}"
+		"de"		"{timer_text}<br>{speed_text}"
+		"ko"		"{timer_text}<br>{speed_text}"
+		"lv"		"{timer_text}<br>{speed_text}"
+	}
 
 	"HUD - HTML Panel Disabled"
 	{
@@ -248,5 +286,13 @@
 		"de"		"{grey}Dein zentrales Informationspanel wurde deaktiviert."
 		"ko"		"{grey}중앙 정보 패널이 비활성화되었습니다."
 		"lv"		"{grey}Jūsu centrālais informācijas panelis ir deaktivizēts."
+	}
+	"HUD Option - Compact Panel - Enable"
+	{
+		"en"		"{grey}Compact panel enabled."
+	}
+	"HUD Option - Compact Panel - Disable"
+	{
+		"en"		"{grey}Compact panel disabled."
 	}
 }


### PR DESCRIPTION
Adds !kz_panel_compact command to show only time and speed. Tested with local preferences. Solves https://github.com/KZGlobalTeam/cs2kz-metamod/issues/496 but with 2 rows since 1 row looks bad.

<img width="549" height="344" alt="image" src="https://github.com/user-attachments/assets/12202024-b657-4b6f-b062-837f078860ec" />