### PR TITLE
Skip random UUID generation when parsing replay UUIDs from filenames

### DIFF
--- a/src/kz/db/set_cheater.cpp
+++ b/src/kz/db/set_cheater.cpp
@@ -56,7 +56,7 @@ void KZDatabaseService::AddOrUpdateBan(u64 steamID64, const char *reason, const 
 	txn.queries.push_back(query);
 
 	// Insert or update a new ban record with specific end time
-	const UUID_t &useId = banId == UUID_t(false) ? UUID_t() : banId;
+	const UUID_t &useId = (banId == UUID_t(false)) ? UUID_t() : banId;
 	std::string banIdStr = useId.ToString();
 	std::string escapedReason = GetDatabaseConnection()->Escape(reason ? reason : "No reason provided");
 	std::string replayUuidStr = replayUuid == UUID_t(false) ? "NULL" : ("'" + replayUuid.ToString() + "'");

--- a/src/kz/global/replays.cpp
+++ b/src/kz/global/replays.cpp
@@ -36,7 +36,7 @@ void KZGlobalService::ReplayManager::ProcessUploads()
 
 void KZGlobalService::ReplayManager::OnReplayRequestSuccess(const std::vector<char> &binaryData, CPlayerUserId userID)
 {
-	UUID_t replayID;
+	UUID_t replayID(false);
 	{
 		std::lock_guard _guard(KZGlobalService::replayManager.mutex);
 		if (KZGlobalService::replayManager.pendingDownload.has_value())

--- a/src/kz/replays/commands.cpp
+++ b/src/kz/replays/commands.cpp
@@ -63,7 +63,7 @@ namespace KZ::replaysystem::commands
 			return;
 		}
 
-		UUID_t parsedUuid;
+		UUID_t parsedUuid(false);
 		if (!UUID_t::FromString(uuid, &parsedUuid))
 		{
 			// Try to find replays matching the UUID substring
@@ -537,7 +537,7 @@ namespace KZ::replaysystem::commands
 
 	static void PlayReplayByID(KZPlayer *player, const char *idStr)
 	{
-		UUID_t uuid;
+		UUID_t uuid(false);
 		if (!UUID_t::FromString(idStr, &uuid))
 		{
 			player->languageService->PrintChat(true, false, "Replay - Not Found");

--- a/src/kz/replays/data.cpp
+++ b/src/kz/replays/data.cpp
@@ -356,7 +356,7 @@ namespace KZ::replaysystem::data
 		}
 		g_pFullFileSystem->Close(file);
 
-		UUID_t uuid = {};
+		UUID_t uuid(false);
 		if (!UUID_t::FromString(CUtlString(path).GetBaseFilename().StripExtension().Get(), &uuid))
 		{
 			return result;

--- a/src/kz/replays/watcher.cpp
+++ b/src/kz/replays/watcher.cpp
@@ -662,7 +662,7 @@ void ReplayWatcher::LoadArchiveIndex()
 		}
 
 		u64 timestamp = member->GetUInt64(0);
-		UUID_t uuid;
+		UUID_t uuid(false);
 		if (UUID_t::FromString(uuidStr, &uuid))
 		{
 			this->archivedIndex[uuid] = timestamp;
@@ -936,7 +936,7 @@ void ReplayWatcher::ScanReplays()
 			{
 				*ext = '\0';
 			}
-			UUID_t uuid;
+			UUID_t uuid(false);
 			if (UUID_t::FromString(uuidStr, &uuid))
 			{
 				char fullPath[MAX_PATH];
@@ -1041,7 +1041,7 @@ void ReplayWatcher::ScanDownloadedReplays(u64 currentTime)
 			{
 				*ext = '\0';
 			}
-			UUID_t uuid;
+			UUID_t uuid(false);
 			if (UUID_t::FromString(uuidStr, &uuid))
 			{
 				char fullPath[MAX_PATH];


### PR DESCRIPTION
## Problem

`ReplayWatcher` re-scans the replay directories every 5s (`WatchLoop` → `ScanReplays` / `ScanDownloadedReplays`, plus `LoadArchiveIndex`) and rebuilds its index by parsing each replay's UUID from its filename with `UUID_t::FromString`. At each of those sites the `UUID_t` is default-constructed first:

```cpp
UUID_t uuid;                              // runs UUID_t::Init()
if (UUID_t::FromString(uuidStr, &uuid))   // overwrites all 16 bytes
```

`UUID_t::Init()` constructs a `std::random_device` and calls it once per byte (16×). `std::random_device` is meant for seeding a PRNG, not bulk generation — each use hits the OS entropy source. Because the watcher mints one throwaway random UUID per replay file on every scan, on a server with a large replay backlog this pegs a CPU core inside `std::random_device`.

Profiling a live server (`perf record` on the game process) showed ~67% of on-CPU samples in `ReplayWatcher::ScanReplays` → `UUID_t::Init()` → `std::random_device::_M_getval()`, all on the watcher thread.

## Fix

`UUID_t` already provides `UUID_t(bool init = true)`. Pass `false` at the three parse sites, since the value is immediately overwritten by `FromString`. No random bytes are generated and UUID generation semantics are unchanged.

## Note

The underlying cost is `UUID_t::Init()` constructing a fresh `std::random_device` and calling it per byte on every UUID it *does* generate. Seeding a `thread_local` PRNG once would be a further improvement, but this change removes the hot path with no behavioral change.
