### PR TITLE
Fix DB SetupMap issue

### DIFF
--- a/src/cs2kz.cpp
+++ b/src/cs2kz.cpp
@@ -174,6 +174,12 @@ void KZPlugin::OnPluginUnload(PluginId id)
 	g_pMenus = (ICS2Menus *)g_SMAPI->MetaFactory(CS2MENUS_INTERFACE, nullptr, nullptr);
 }
 
+void KZPlugin::OnLevelInit(char const *pMapName, char const *pMapEntities, char const *pOldLevel, char const *pLandmarkName, bool loadGame,
+						   bool background)
+{
+	m_sCurrentMap = pMapName;
+}
+
 void KZPlugin::AddonInit()
 {
 	static_persist bool addonLoaded;

--- a/src/cs2kz.h
+++ b/src/cs2kz.h
@@ -63,6 +63,8 @@ public:
 	virtual void *OnMetamodQuery(const char *iface, int *ret) override;
 	virtual void OnPluginLoad(PluginId id) override;
 	virtual void OnPluginUnload(PluginId id) override;
+	virtual void OnLevelInit(char const *pMapName, char const *pMapEntities, char const *pOldLevel, char const *pLandmarkName, bool loadGame,
+							 bool background) override;
 
 	bool simulatingPhysics = false;
 	CGlobalVars serverGlobals;
@@ -71,10 +73,16 @@ public:
 private:
 	void UpdateSelfMD5();
 	char md5[33];
+	std::string m_sCurrentMap;
 
 public:
 	std::string_view GetMD5()
 	{
 		return md5;
+	}
+
+	std::string_view GetCurrentMap()
+	{
+		return m_sCurrentMap;
 	}
 };

--- a/src/kz/db/setup_map.cpp
+++ b/src/kz/db/setup_map.cpp
@@ -62,10 +62,10 @@ void KZDatabaseService::SetupMap()
 		txn, 
 		[databaseType, mapName](std::vector<ISQLQuery *> queries) 
 		{
-			auto currentMapName = g_pKZUtils->GetCurrentMapName();
+			auto currentMapName = g_pKZUtils->GetCurrentMapName().Get();
 			if (!KZ_STREQ(currentMapName, mapName.Get()))
 			{
-				KZ_LOG_WARN(LogChannel::DB, "Failed to setup map, current map name %s doesn't match %s!\n", currentMapName.Get(), mapName.Get());
+				KZ_LOG_WARN(LogChannel::DB, "Failed to setup map, current map name %s doesn't match %s!\n", currentMapName, mapName.Get());
 				return;
 			}
 			switch (databaseType)
@@ -95,7 +95,7 @@ void KZDatabaseService::SetupMap()
 				}
 			}
 			mapSetUp = true;
-			KZ_LOG_INFO(LogChannel::DB, "Map setup successful for %s, current map ID: %i\n", currentMapName.Get(), KZDatabaseService::currentMapID);
+			KZ_LOG_INFO(LogChannel::DB, "Map setup successful for %s, current map ID: %i\n", currentMapName, KZDatabaseService::currentMapID);
 			CALL_FORWARD(eventListeners, OnMapSetup);
 		},
 		OnGenericTxnFailure);

--- a/src/kz/db/setup_map.cpp
+++ b/src/kz/db/setup_map.cpp
@@ -62,10 +62,10 @@ void KZDatabaseService::SetupMap()
 		txn, 
 		[databaseType, mapName](std::vector<ISQLQuery *> queries) 
 		{
-			auto currentMapName = g_pKZUtils->GetCurrentMapName().Get();
-			if (!KZ_STREQ(currentMapName, mapName.Get()))
+			CUtlString currentMapName = g_pKZUtils->GetCurrentMapName();
+			if (!KZ_STREQ(currentMapName.Get(), mapName.Get()))
 			{
-				KZ_LOG_WARN(LogChannel::DB, "Failed to setup map, current map name %s doesn't match %s!\n", currentMapName, mapName.Get());
+				KZ_LOG_WARN(LogChannel::DB, "Failed to setup map, current map name %s doesn't match %s!\n", currentMapName.Get(), mapName.Get());
 				return;
 			}
 			switch (databaseType)
@@ -95,7 +95,7 @@ void KZDatabaseService::SetupMap()
 				}
 			}
 			mapSetUp = true;
-			KZ_LOG_INFO(LogChannel::DB, "Map setup successful for %s, current map ID: %i\n", currentMapName, KZDatabaseService::currentMapID);
+			KZ_LOG_INFO(LogChannel::DB, "Map setup successful for %s, current map ID: %i\n", currentMapName.Get(), KZDatabaseService::currentMapID);
 			CALL_FORWARD(eventListeners, OnMapSetup);
 		},
 		OnGenericTxnFailure);

--- a/src/kz/db/setup_map.cpp
+++ b/src/kz/db/setup_map.cpp
@@ -65,7 +65,7 @@ void KZDatabaseService::SetupMap()
 			auto currentMapName = g_pKZUtils->GetCurrentMapName();
 			if (!KZ_STREQ(currentMapName, mapName.Get()))
 			{
-				KZ_LOG_WARN(LogChannel::DB, "Failed to setup map, current map name %s doesn't match %s!\n", currentMapName, mapName.Get());
+				KZ_LOG_WARN(LogChannel::DB, "Failed to setup map, current map name %s doesn't match %s!\n", currentMapName.Get(), mapName.Get());
 				return;
 			}
 			switch (databaseType)
@@ -95,7 +95,7 @@ void KZDatabaseService::SetupMap()
 				}
 			}
 			mapSetUp = true;
-			KZ_LOG_INFO(LogChannel::DB, "Map setup successful for %s, current map ID: %i\n", currentMapName, KZDatabaseService::currentMapID);
+			KZ_LOG_INFO(LogChannel::DB, "Map setup successful for %s, current map ID: %i\n", currentMapName.Get(), KZDatabaseService::currentMapID);
 			CALL_FORWARD(eventListeners, OnMapSetup);
 		},
 		OnGenericTxnFailure);

--- a/src/kz/db/setup_map.cpp
+++ b/src/kz/db/setup_map.cpp
@@ -28,7 +28,7 @@ void KZDatabaseService::SetupMap()
 
 	Transaction txn;
 	char query[2048];
-	CUtlString mapName = g_pKZUtils->GetServerGlobals()->mapname.ToCStr();
+	CUtlString mapName = g_pKZUtils->GetCurrentMapName();
 	auto escapedMapName = KZDatabaseService::GetDatabaseConnection()->Escape(mapName.Get());
 	auto databaseType = KZDatabaseService::GetDatabaseType();
 	switch (databaseType)
@@ -62,7 +62,7 @@ void KZDatabaseService::SetupMap()
 		txn, 
 		[databaseType, mapName](std::vector<ISQLQuery *> queries) 
 		{
-			auto currentMapName = g_pKZUtils->GetServerGlobals()->mapname.ToCStr();
+			auto currentMapName = g_pKZUtils->GetCurrentMapName();
 			if (!KZ_STREQ(currentMapName, mapName.Get()))
 			{
 				KZ_LOG_WARN(LogChannel::DB, "Failed to setup map, current map name %s doesn't match %s!\n", currentMapName, mapName.Get());

--- a/src/utils/utils_interface.cpp
+++ b/src/utils/utils_interface.cpp
@@ -138,14 +138,15 @@ CUtlString KZUtils::GetCurrentMapName(bool *result)
 		return networkGameServer->GetMapName();
 	}
 
-	const CGlobalVars *globals = g_pKZUtils->GetGlobals();
-	if (globals && strlen(globals->mapname.ToCStr()))
+	auto currentMap = g_KZPlugin.GetCurrentMap();
+	if (currentMap.length() > 0)
 	{
 		if (result)
 		{
 			*result = true;
 		}
-		return globals->mapname.ToCStr();
+
+		return currentMap.data();
 	}
 
 	if (result)


### PR DESCRIPTION
It sometimes happend on map changing.
`[CS2KZ::DB] [WARN] Failed to setup map, current map name �G39+ doesn't match kz_concrete!`

This PR also provides a safer way to get the CurrentMap, and prevents interference from garbage data in CGlobalVars.