### PR TITLE
GlobalService WebSocket refactor

### DIFF
--- a/src/cs2kz.cpp
+++ b/src/cs2kz.cpp
@@ -78,6 +78,9 @@ bool KZPlugin::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen, bool
 		snprintf(error, maxlen, "Failed to initialize movement detours.");
 		return false;
 	}
+
+	ix::initNetSystem();
+
 	KZCheckpointService::Init();
 	KZTimerService::Init();
 	KZSpecService::Init();
@@ -139,6 +142,7 @@ bool KZPlugin::Unload(char *error, size_t maxlen)
 	KZOptionService::Cleanup();
 	KZ::replaysystem::Cleanup();
 	KZAnticheatService::CleanupSvCheatsWatcher();
+	ix::uninitNetSystem();
 	hooks::Cleanup();
 	utils::Cleanup();
 	LoggingSystem_UnregisterLoggingListener(&g_KZLoggingListener);

--- a/src/kz/global/kz_global.cpp
+++ b/src/kz/global/kz_global.cpp
@@ -97,13 +97,14 @@ void KZGlobalService::Cleanup()
 {
 	if (KZGlobalService::WS::socket)
 	{
-		{
-			std::lock_guard<std::mutex> guard(KZGlobalService::WS::socketThreadState.mutex);
-			KZGlobalService::WS::socketThreadState.Notify(std::move(guard), KZGlobalService::WS::SocketThreadState::Signal::ShuttingDown);
-		}
-
 		if (KZGlobalService::WS::socketThread.joinable())
 		{
+			{
+				std::lock_guard<std::mutex> guard(KZGlobalService::WS::socketThreadState.mutex);
+				KZGlobalService::WS::socketThreadState.shuttingDown = true;
+				KZGlobalService::WS::socketThreadState.cvar.notify_one();
+			}
+
 			KZGlobalService::WS::socketThread.join();
 		}
 	}
@@ -513,48 +514,55 @@ void KZGlobalService::OnClientDisconnect()
 void KZGlobalService::WS::Run()
 {
 	auto &state = KZGlobalService::WS::socketThreadState;
-	u64 lastSignalNr = 0;
-
-	{
-		std::lock_guard<std::mutex> guard(state.mutex);
-		state.lastSignalNr = lastSignalNr;
-	}
 
 	KZGlobalService::WS::socket->start();
 
 	while (true)
 	{
 		std::unique_lock<std::mutex> guard(state.mutex);
-		state.cvar.wait(guard, [&] { return state.lastSignalNr != lastSignalNr; });
+		state.cvar.wait(guard, [&] { return state.shuttingDown || !state.sendQueue.empty(); });
 
-		switch (state.lastSignal)
+		KZ_LOG_DEBUG(LogChannel::Global, "WS thread woke up\n");
+
+		if (state.shuttingDown)
 		{
-			case SocketThreadState::Signal::ShuttingDown:
-			{
-				KZGlobalService::WS::socket->stop();
-				KZGlobalService::state.store(KZGlobalService::State::Disconnected);
-				KZGlobalService::WS::socket.reset(nullptr);
-				return;
-			}
+			KZ_LOG_DEBUG(LogChannel::Global, "WS thread shutting down...\n");
+			KZGlobalService::WS::socket->stop();
+			KZGlobalService::state.store(KZGlobalService::State::Disconnected);
+			KZGlobalService::WS::socket.reset(nullptr);
 
-			case SocketThreadState::Signal::MessageEnqueued:
+			for (auto it = state.sendQueue.begin(); it != state.sendQueue.end();)
 			{
-				for (auto it = state.sendQueue.begin(); it != state.sendQueue.end();)
+				if (it->retainAfterDisconnect)
 				{
-					if (KZGlobalService::WS::socket->send(it->payload).success)
-					{
-						KZ_LOG_DEBUG(LogChannel::Global, "Sent WebSocket message.\n");
-						it = state.sendQueue.erase(it);
-					}
-					else
-					{
-						break;
-					}
+					++it;
+				}
+				else
+				{
+					it = state.sendQueue.erase(it);
 				}
 			}
+
 			break;
 		}
+
+		KZ_LOG_DEBUG(LogChannel::Global, "sending messages\n");
+
+		for (auto it = state.sendQueue.begin(); it != state.sendQueue.end();)
+		{
+			if (KZGlobalService::WS::socket->send(it->payload).success)
+			{
+				KZ_LOG_DEBUG(LogChannel::Global, "Sent WebSocket message.\n");
+				it = state.sendQueue.erase(it);
+			}
+			else
+			{
+				break;
+			}
+		}
 	}
+
+	KZ_LOG_DEBUG(LogChannel::Global, "WS thread exiting...\n");
 }
 
 void KZGlobalService::WS::OnMessage(const ix::WebSocketMessagePtr &message)
@@ -702,21 +710,6 @@ void KZGlobalService::WS::OnCloseMessage(const ix::WebSocketCloseInfo &closeInfo
 	{
 		std::lock_guard _guard(KZGlobalService::callbacks.mutex);
 		KZGlobalService::callbacks.queue.clear();
-	}
-
-	{
-		std::lock_guard _messagesQueueGuard(KZGlobalService::ws.socketThreadState.mutex);
-		for (auto it = KZGlobalService::ws.socketThreadState.sendQueue.begin(); it != KZGlobalService::ws.socketThreadState.sendQueue.end();)
-		{
-			if (it->retainAfterDisconnect)
-			{
-				++it;
-			}
-			else
-			{
-				it = KZGlobalService::ws.socketThreadState.sendQueue.erase(it);
-			}
-		}
 	}
 
 	{

--- a/src/kz/global/kz_global.cpp
+++ b/src/kz/global/kz_global.cpp
@@ -364,13 +364,11 @@ void KZGlobalService::OnServerGamePostSimulate()
 					}
 					else
 					{
-						callbackHandle.mapped()->OnResponse(it->id, it->payload, it->binaryData);
+						callbackHandle.mapped()->OnResponse(it->id, it->payload);
 					}
 
 					it = KZGlobalService::ws.receivedMessages.queue.erase(it);
 				}
-
-				KZGlobalService::ws.receivedMessages.queue.clear();
 
 				{
 					std::lock_guard _messageCallbacksQueueGuard(KZGlobalService::ws.messageCallbacks.mutex);
@@ -543,7 +541,7 @@ void KZGlobalService::WS::Run()
 			{
 				for (auto it = state.sendQueue.begin(); it != state.sendQueue.end();)
 				{
-					if (KZGlobalService::WS::socket->send(*it).success)
+					if (KZGlobalService::WS::socket->send(it->payload).success)
 					{
 						KZ_LOG_DEBUG(LogChannel::Global, "Sent WebSocket message.\n");
 						it = state.sendQueue.erase(it);
@@ -588,25 +586,7 @@ void KZGlobalService::WS::OnMessage(const ix::WebSocketMessagePtr &message)
 				 "\n----------------------------------------\n",
 				 message->str.c_str());
 
-	// Binary frames carry: <json>\n<binary-data>
-	// Text frames are pure JSON.
-	std::string_view jsonPart = message->str;
-	std::vector<char> binaryPart;
-
-	if (message->binary)
-	{
-		auto newlinePos = message->str.find('\n');
-		if (newlinePos != std::string::npos)
-		{
-			jsonPart = std::string_view(message->str.data(), newlinePos);
-			const char *binStart = message->str.data() + newlinePos + 1;
-			size_t binLen = message->str.size() - newlinePos - 1;
-			binaryPart.assign(binStart, binStart + binLen);
-		}
-	}
-
-	std::string jsonStr(jsonPart);
-	Json payload(jsonStr);
+	Json payload(message->str);
 
 	if (!payload.IsValid())
 	{
@@ -655,7 +635,6 @@ void KZGlobalService::WS::OnMessage(const ix::WebSocketMessagePtr &message)
 			ReceivedMessage receivedMessage;
 			receivedMessage.id = messageID;
 			receivedMessage.isError = (event == "error");
-			receivedMessage.binaryData = std::move(binaryPart);
 
 			if (!payload.Get("data", receivedMessage.payload))
 			{
@@ -723,6 +702,21 @@ void KZGlobalService::WS::OnCloseMessage(const ix::WebSocketCloseInfo &closeInfo
 	{
 		std::lock_guard _guard(KZGlobalService::callbacks.mutex);
 		KZGlobalService::callbacks.queue.clear();
+	}
+
+	{
+		std::lock_guard _messagesQueueGuard(KZGlobalService::ws.socketThreadState.mutex);
+		for (auto it = KZGlobalService::ws.socketThreadState.sendQueue.begin(); it != KZGlobalService::ws.socketThreadState.sendQueue.end();)
+		{
+			if (it->retainAfterDisconnect)
+			{
+				++it;
+			}
+			else
+			{
+				it = KZGlobalService::ws.socketThreadState.sendQueue.erase(it);
+			}
+		}
 	}
 
 	{

--- a/src/kz/global/kz_global.cpp
+++ b/src/kz/global/kz_global.cpp
@@ -84,8 +84,6 @@ void KZGlobalService::Init()
 
 	KZGlobalService::EnforceConVars();
 
-	ix::initNetSystem();
-
 	KZGlobalService::WS::socket = std::make_unique<ix::WebSocket>();
 	KZGlobalService::WS::socket->setUrl(apiUrl);
 	KZGlobalService::WS::socket->setExtraHeaders({{"Authorization", std::string("Bearer ") + apiKey}});
@@ -99,11 +97,15 @@ void KZGlobalService::Cleanup()
 {
 	if (KZGlobalService::WS::socket)
 	{
-		KZGlobalService::WS::socket->stop();
-		KZGlobalService::state.store(KZGlobalService::State::Disconnected);
-		KZGlobalService::WS::socket.reset(nullptr);
+		{
+			std::lock_guard<std::mutex> guard(KZGlobalService::WS::socketThreadState.mutex);
+			KZGlobalService::WS::socketThreadState.Notify(std::move(guard), KZGlobalService::WS::SocketThreadState::Signal::ShuttingDown);
+		}
 
-		ix::uninitNetSystem();
+		if (KZGlobalService::WS::socketThread.joinable())
+		{
+			KZGlobalService::WS::socketThread.join();
+		}
 	}
 
 	KZGlobalService::state.store(KZGlobalService::State::Uninitialized);
@@ -264,7 +266,7 @@ void KZGlobalService::OnActivateServer()
 		case KZGlobalService::State::Configured:
 		{
 			KZ_LOG_INFO(LogChannel::Global, "Starting WebSocket...\n");
-			KZGlobalService::WS::socket->start();
+			KZGlobalService::WS::socketThread = std::thread([]() { return KZGlobalService::WS::Run(); });
 			KZGlobalService::state.store(KZGlobalService::State::Connecting);
 		}
 		break;
@@ -508,6 +510,53 @@ void KZGlobalService::OnClientDisconnect()
 	}
 
 	KZGlobalService::WS::SendMessage(message);
+}
+
+void KZGlobalService::WS::Run()
+{
+	auto &state = KZGlobalService::WS::socketThreadState;
+	u64 lastSignalNr = 0;
+
+	{
+		std::lock_guard<std::mutex> guard(state.mutex);
+		state.lastSignalNr = lastSignalNr;
+	}
+
+	KZGlobalService::WS::socket->start();
+
+	while (true)
+	{
+		std::unique_lock<std::mutex> guard(state.mutex);
+		state.cvar.wait(guard, [&] { return state.lastSignalNr != lastSignalNr; });
+
+		switch (state.lastSignal)
+		{
+			case SocketThreadState::Signal::ShuttingDown:
+			{
+				KZGlobalService::WS::socket->stop();
+				KZGlobalService::state.store(KZGlobalService::State::Disconnected);
+				KZGlobalService::WS::socket.reset(nullptr);
+				return;
+			}
+
+			case SocketThreadState::Signal::MessageEnqueued:
+			{
+				for (auto it = state.sendQueue.begin(); it != state.sendQueue.end();)
+				{
+					if (KZGlobalService::WS::socket->send(*it).success)
+					{
+						KZ_LOG_DEBUG(LogChannel::Global, "Sent WebSocket message.\n");
+						it = state.sendQueue.erase(it);
+					}
+					else
+					{
+						break;
+					}
+				}
+			}
+			break;
+		}
+	}
 }
 
 void KZGlobalService::WS::OnMessage(const ix::WebSocketMessagePtr &message)

--- a/src/kz/global/kz_global.h
+++ b/src/kz/global/kz_global.h
@@ -347,6 +347,28 @@ private:
 
 		// INVARIANT: should be `nullptr` when `state == Uninitialized`, and a valid pointer otherwise
 		static inline std::unique_ptr<ix::WebSocket> socket = nullptr;
+		static inline std::thread socketThread;
+
+		static inline struct SocketThreadState
+		{
+			enum class Signal
+			{
+				MessageEnqueued,
+				ShuttingDown,
+			} lastSignal;
+			u64 lastSignalNr;
+
+			std::mutex mutex;
+			std::condition_variable cvar;
+			std::vector<std::string> sendQueue;
+
+			inline void Notify(std::lock_guard<std::mutex> &&guard, Signal signal)
+			{
+				lastSignal = signal;
+				++lastSignalNr;
+				cvar.notify_one();
+			}
+		} socketThreadState;
 
 		/**
 		 * WebSocket messages we have received, but not yet processed.
@@ -371,6 +393,8 @@ private:
 			std::mutex mutex;
 			std::unordered_map<u32, std::unique_ptr<MessageCallbackInternal>> callbacks;
 		} messageCallbacks;
+
+		static void Run();
 
 		/**
 		 * Callback for `IXWebSocket`; called on every received message.
@@ -503,30 +527,36 @@ private:
 
 			std::string encodedPayload = messagePayload.ToString();
 
-			if (binaryData && !binaryData->empty())
-			{
-				// Combine JSON text + binary data into a single binary frame, delimited by newline.
-				// Strip any newlines from the JSON so the delimiter is unambiguous.
-				encodedPayload.erase(std::remove(encodedPayload.begin(), encodedPayload.end(), '\n'), encodedPayload.end());
-				std::string combined;
-				combined.reserve(encodedPayload.size() + 1 + binaryData->size());
-				combined.append(encodedPayload);
-				combined.push_back('\n');
-				combined.append(binaryData->data(), binaryData->size());
-				socket->sendBinary(combined);
-			}
-			else
-			{
-				socket->send(encodedPayload);
-			}
+			// if (binaryData && !binaryData->empty())
+			// {
+			// 	// Combine JSON text + binary data into a single binary frame, delimited by newline.
+			// 	// Strip any newlines from the JSON so the delimiter is unambiguous.
+			// 	encodedPayload.erase(std::remove(encodedPayload.begin(), encodedPayload.end(), '\n'), encodedPayload.end());
+			// 	std::string combined;
+			// 	combined.reserve(encodedPayload.size() + 1 + binaryData->size());
+			// 	combined.append(encodedPayload);
+			// 	combined.push_back('\n');
+			// 	combined.append(binaryData->data(), binaryData->size());
+			// 	socket->sendBinary(combined);
+			// }
+			// else
+			// {
+			// 	socket->send(encodedPayload);
+			// }
 
 			// clang-format off
-			KZ_LOG_DEBUG(LogChannel::Global, "Sent WebSocket message. (id=%i, type=%s)\n"
+			KZ_LOG_DEBUG(LogChannel::Global, "Sending WebSocket message (id=%i, type=%s)...\n"
 					"------------------------------------\n"
 					"%s\n"
 					"------------------------------------\n",
 					messageID, messageType, encodedPayload.c_str());
 			// clang-format on
+
+			{
+				std::lock_guard<std::mutex> guard(socketThreadState.mutex);
+				socketThreadState.sendQueue.push_back(std::move(encodedPayload));
+				socketThreadState.Notify(std::move(guard), SocketThreadState::Signal::MessageEnqueued);
+			}
 
 			return true;
 		}

--- a/src/kz/global/kz_global.h
+++ b/src/kz/global/kz_global.h
@@ -274,12 +274,7 @@ private:
 			std::mutex mutex;
 			std::condition_variable cvar;
 
-			enum class Signal
-			{
-				MessageEnqueued,
-				ShuttingDown,
-			} lastSignal;
-			u64 lastSignalNr;
+			bool shuttingDown;
 
 			struct EnqueuedMessage
 			{
@@ -288,13 +283,6 @@ private:
 			};
 
 			std::vector<EnqueuedMessage> sendQueue;
-
-			inline void Notify(std::lock_guard<std::mutex> &&guard, Signal signal)
-			{
-				lastSignal = signal;
-				++lastSignalNr;
-				cvar.notify_one();
-			}
 		} socketThreadState;
 
 		/**
@@ -452,7 +440,7 @@ private:
 			{
 				std::lock_guard<std::mutex> guard(socketThreadState.mutex);
 				socketThreadState.sendQueue.push_back({std::move(encodedPayload), retainAfterDisconnect});
-				socketThreadState.Notify(std::move(guard), SocketThreadState::Signal::MessageEnqueued);
+				socketThreadState.cvar.notify_one();
 			}
 
 			return true;

--- a/src/kz/global/kz_global.h
+++ b/src/kz/global/kz_global.h
@@ -131,7 +131,7 @@ public:
 		template<typename OnResponse, typename... Args>
 		explicit MessageCallback(OnResponse &&onResponse, Args &&...args)
 			: onResponse([cb = std::bind(std::move(onResponse), std::placeholders::_1, std::forward<Args>(args)...)] (const Response &response) { cb(response); })
-				, onError([](const KZ::api::messages::Error &) {})
+			, onError([](const KZ::api::messages::Error &) {})
 			, onCancelled([](CancelReason) {})
 		// clang-format on
 		{

--- a/src/kz/global/kz_global.h
+++ b/src/kz/global/kz_global.h
@@ -62,7 +62,7 @@ private:
 		std::chrono::time_point<std::chrono::system_clock> sentAt;
 		std::chrono::seconds expiresAfter = std::chrono::seconds(5);
 
-		virtual void OnResponse(u32 messageID, const Json &payload, const std::vector<char> &binaryData) = 0;
+		virtual void OnResponse(u32 messageID, const Json &payload) = 0;
 
 		virtual void OnError(u32 messageID, const KZ::api::messages::Error &error)
 		{
@@ -93,89 +93,14 @@ private:
 	};
 
 public:
-	template<typename Response, bool WithBinaryData = false>
-	class MessageCallback : public MessageCallbackInternal
-	{
-		// clang-format off
-		using OnResponseFn = std::conditional_t<WithBinaryData,
-			std::function<void(const Response &, const std::vector<char> &)>,
-			std::function<void(const Response &)>>;
-		// clang-format on
-
-		OnResponseFn onResponse;
-		std::function<void(const KZ::api::messages::Error &)> onError;
-		std::function<void(CancelReason)> onCancelled;
-
-		void OnResponse(u32 messageID, const Json &payload, const std::vector<char> &binaryData) override
-		{
-			Response response;
-
-			if (payload.Decode(response))
-			{
-				if constexpr (WithBinaryData)
-				{
-					this->onResponse(response, binaryData);
-				}
-				else
-				{
-					this->onResponse(response);
-				}
-			}
-			else
-			{
-				KZ_LOG_WARN(LogChannel::Global, "Received unknown payload as WebSocket response. (id=%i)\n", messageID);
-			}
-		}
-
-		void OnError(u32 messageID, const KZ::api::messages::Error &error) override
-		{
-			MessageCallbackInternal::OnError(messageID, error);
-			this->onError(error);
-		}
-
-		void OnCancelled(u32 messageID, CancelReason reason) override
-		{
-			MessageCallbackInternal::OnCancelled(messageID, reason);
-			this->onCancelled(reason);
-		}
-
-	public:
-		// clang-format off
-		template<typename OnResponse, typename... Args>
-		explicit MessageCallback(OnResponse &&onResponse, Args &&...args)
-			: onResponse([cb = std::bind(std::move(onResponse), std::placeholders::_1, std::placeholders::_2, std::forward<Args>(args)...)] (const Response &response, const std::vector<char> &binaryData) { cb(response, binaryData); })
-			, onError([](const KZ::api::messages::Error &) {})
-			, onCancelled([](CancelReason) {})
-		// clang-format on
-		{
-		}
-
-		inline void Timeout(std::chrono::seconds duration)
-		{
-			this->expiresAfter = duration;
-		}
-
-		template<typename CB>
-		void OnError(CB &&onError)
-		{
-			this->onError = std::move(onError);
-		}
-
-		template<typename CB>
-		void OnCancelled(CB &&onCancelled)
-		{
-			this->onCancelled = std::move(onCancelled);
-		}
-	};
-
 	template<typename Response>
-	class MessageCallback<Response, false> : public MessageCallbackInternal
+	class MessageCallback : public MessageCallbackInternal
 	{
 		std::function<void(const Response &)> onResponse;
 		std::function<void(const KZ::api::messages::Error &)> onError;
 		std::function<void(CancelReason)> onCancelled;
 
-		void OnResponse(u32 messageID, const Json &payload, const std::vector<char> &) override
+		void OnResponse(u32 messageID, const Json &payload) override
 		{
 			Response response;
 
@@ -206,7 +131,7 @@ public:
 		template<typename OnResponse, typename... Args>
 		explicit MessageCallback(OnResponse &&onResponse, Args &&...args)
 			: onResponse([cb = std::bind(std::move(onResponse), std::placeholders::_1, std::forward<Args>(args)...)] (const Response &response) { cb(response); })
-			, onError([](const KZ::api::messages::Error &) {})
+				, onError([](const KZ::api::messages::Error &) {})
 			, onCancelled([](CancelReason) {})
 		// clang-format on
 		{
@@ -338,11 +263,6 @@ private:
 			 * The rest of the payload, which will be parsed according to `MessageType` later.
 			 */
 			Json payload;
-
-			/**
-			 * Optional binary payload appended after the JSON in the same WebSocket frame.
-			 */
-			std::vector<char> binaryData;
 		};
 
 		// INVARIANT: should be `nullptr` when `state == Uninitialized`, and a valid pointer otherwise
@@ -351,6 +271,9 @@ private:
 
 		static inline struct SocketThreadState
 		{
+			std::mutex mutex;
+			std::condition_variable cvar;
+
 			enum class Signal
 			{
 				MessageEnqueued,
@@ -358,9 +281,13 @@ private:
 			} lastSignal;
 			u64 lastSignalNr;
 
-			std::mutex mutex;
-			std::condition_variable cvar;
-			std::vector<std::string> sendQueue;
+			struct EnqueuedMessage
+			{
+				std::string payload;
+				bool retainAfterDisconnect = false;
+			};
+
+			std::vector<EnqueuedMessage> sendQueue;
 
 			inline void Notify(std::lock_guard<std::mutex> &&guard, Signal signal)
 			{
@@ -449,18 +376,6 @@ private:
 		}
 
 		/**
-		 * Sends the given payload as a WebSocket message with binary data appended after the JSON.
-		 */
-		template<typename Payload>
-		static bool SendMessageWithBinary(const Payload &payload, const std::vector<char> &binaryData)
-		{
-			u32 messageID;
-			const char *messageType;
-			Json messagePayload;
-			return SendMessageImpl(messageID, messageType, messagePayload, payload, &binaryData);
-		}
-
-		/**
 		 * Sends the given payload as a WebSocket message and queues the given `callback` to be executed when a response is received.
 		 */
 		template<typename Payload, typename Callback>
@@ -499,12 +414,11 @@ private:
 		 * Implementation detail of `SendMessage()`.
 		 *
 		 * It initializes the first 3 parameters and encodes `Payload`.
-		 * If `binaryData` is non-null, the JSON text is concatenated with the binary buffer
-		 * and sent as a single binary WebSocket frame.
+		 * If `retainAfterDisconnect` is set to `true`, the message won't be removed from the queue in case of a disconnect.
 		 */
 		template<typename Payload>
 		static bool SendMessageImpl(u32 &messageID, const char *&messageType, Json &messagePayload, const Payload &payload,
-									const std::vector<char> *binaryData = nullptr)
+									bool retainAfterDisconnect = false)
 		{
 			messageID = NextMessageID();
 			KZ_LOG_DEBUG(LogChannel::Global, "assigned message ID %i\n", messageID);
@@ -527,23 +441,6 @@ private:
 
 			std::string encodedPayload = messagePayload.ToString();
 
-			// if (binaryData && !binaryData->empty())
-			// {
-			// 	// Combine JSON text + binary data into a single binary frame, delimited by newline.
-			// 	// Strip any newlines from the JSON so the delimiter is unambiguous.
-			// 	encodedPayload.erase(std::remove(encodedPayload.begin(), encodedPayload.end(), '\n'), encodedPayload.end());
-			// 	std::string combined;
-			// 	combined.reserve(encodedPayload.size() + 1 + binaryData->size());
-			// 	combined.append(encodedPayload);
-			// 	combined.push_back('\n');
-			// 	combined.append(binaryData->data(), binaryData->size());
-			// 	socket->sendBinary(combined);
-			// }
-			// else
-			// {
-			// 	socket->send(encodedPayload);
-			// }
-
 			// clang-format off
 			KZ_LOG_DEBUG(LogChannel::Global, "Sending WebSocket message (id=%i, type=%s)...\n"
 					"------------------------------------\n"
@@ -554,7 +451,7 @@ private:
 
 			{
 				std::lock_guard<std::mutex> guard(socketThreadState.mutex);
-				socketThreadState.sendQueue.push_back(std::move(encodedPayload));
+				socketThreadState.sendQueue.push_back({std::move(encodedPayload), retainAfterDisconnect});
 				socketThreadState.Notify(std::move(guard), SocketThreadState::Signal::MessageEnqueued);
 			}
 
@@ -857,8 +754,6 @@ private:
 	static inline struct ReplayManager
 	{
 		std::mutex mutex;
-		// Message example:
-		// {"event":"new-replay","data":{"id":"a14ca802-0449-4441-8d19-08aeee7c2f9a"}}<BINARY DATA>
 		std::vector<std::pair<UUID_t, std::vector<char>>> pendingUploads;
 
 		bool QueueUpload(const UUID_t &uploadID, std::vector<char> &&replayData);

--- a/src/kz/global/messages.cpp
+++ b/src/kz/global/messages.cpp
@@ -263,7 +263,7 @@ bool KZ::api::messages::PlayerRecords::FromJson(const Json &json)
 	return json.Get("records", this->records);
 }
 
-bool KZ::api::messages::NewReplay::ToJson(Json &json) const
-{
-	return json.Set("id", this->replayID);
-}
+// bool KZ::api::messages::NewReplay::ToJson(Json &json) const
+// {
+// 	return json.Set("id", this->replayID);
+// }

--- a/src/kz/global/messages.h
+++ b/src/kz/global/messages.h
@@ -320,28 +320,28 @@ namespace KZ::api::messages
 		bool FromJson(const Json &json);
 	};
 
-	struct NewReplay
-	{
-		std::string_view replayID;
-
-		inline static const char *Name()
-		{
-			return "new-replay";
-		}
-
-		bool ToJson(Json &json) const;
-	};
-
-	struct ReplayData
-	{
-		inline static const char *Name()
-		{
-			return "replay-data";
-		}
-
-		bool FromJson(const Json &json)
-		{
-			return true;
-		}
-	};
+	// struct NewReplay
+	// {
+	// 	std::string_view replayID;
+	//
+	// 	inline static const char *Name()
+	// 	{
+	// 		return "new-replay";
+	// 	}
+	//
+	// 	bool ToJson(Json &json) const;
+	// };
+	//
+	// struct ReplayData
+	// {
+	// 	inline static const char *Name()
+	// 	{
+	// 		return "replay-data";
+	// 	}
+	//
+	// 	bool FromJson(const Json &json)
+	// 	{
+	// 		return true;
+	// 	}
+	// };
 }; // namespace KZ::api::messages

--- a/src/kz/global/replays.cpp
+++ b/src/kz/global/replays.cpp
@@ -30,7 +30,8 @@ void KZGlobalService::ReplayManager::ProcessUploads()
 
 	for (auto &[uploadID, replayData] : uploadsToProcess)
 	{
-		KZGlobalService::WS::SendMessageWithBinary(KZ::api::messages::NewReplay {uploadID.ToString()}, replayData);
+		// TODO: upload via http
+		// KZGlobalService::WS::SendMessageWithBinary(KZ::api::messages::NewReplay {uploadID.ToString()}, replayData);
 	}
 }
 


### PR DESCRIPTION
This PR moves the `ix::WebSocket::send()` operations to a dedicated thread, to avoid blocking the main thread on I/O operations. It also gets rid of binary messages, in preparation for a future PR that replaces replay uploads with HTTP requests.